### PR TITLE
Additional pathogenic expansion loci.

### DIFF
--- a/ExpansionHunter-v2.5.5/AFF2.json
+++ b/ExpansionHunter-v2.5.5/AFF2.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "AFF2",
+    "RepeatUnit": "GCC",
+    "TargetRegion": "X:147582158-147582202"
+}

--- a/ExpansionHunter-v2.5.5/ATXN8OS.json
+++ b/ExpansionHunter-v2.5.5/ATXN8OS.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "ATXN8OS",
+    "RepeatUnit": "CTG",
+    "TargetRegion": "13:70713516-70713560"
+}

--- a/ExpansionHunter-v2.5.5/CNBP.json
+++ b/ExpansionHunter-v2.5.5/CNBP.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "CNBP",
+    "RepeatUnit": "GGCA",
+    "TargetRegion": "3:128891421-128891501"
+}

--- a/ExpansionHunter-v2.5.5/NOP56.json
+++ b/ExpansionHunter-v2.5.5/NOP56.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "NOP56",
+    "RepeatUnit": "GGCCTG",
+    "TargetRegion": "20:2633380-2633403"
+}

--- a/ExpansionHunter-v2.5.5/PAPBN1.json
+++ b/ExpansionHunter-v2.5.5/PAPBN1.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "PABPN1",
+    "RepeatUnit": "GCG",
+    "TargetRegion": "14:23790682-23790699"
+}

--- a/ExpansionHunter-v2.5.5/TBP.json
+++ b/ExpansionHunter-v2.5.5/TBP.json
@@ -1,0 +1,6 @@
+{
+    "CommonUnit": "true",
+    "RepeatId": "TBP",
+    "RepeatUnit": "CAG",
+    "TargetRegion": "6:170870996-170871109"
+}


### PR DESCRIPTION
Note that this will be obsolete with ExpansionHunter v3 and above, where these are included (and better detected).