### PR TITLE
Update OPMD (PAPBPN1)

### DIFF
--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch37.json
@@ -375,11 +375,12 @@
     {
         "VariantType": "Repeat",
         "LocusId": "PABPN1",
-        "LocusStructure": "(GCG)*",
-        "ReferenceRegion": "14:23790681-23790699",
+        "LocusStructure": "(GCN)*",
+        "ReferenceRegion": "14:23790681-23790711",
         "Disease": "OPMD",
-        "NormalMax": 6,
-        "PathologicMin": 9
+        "NormalMax": 10,
+        "PathologicMin": 11,
+        "Source": "GeneReviews Internet 2014-02-20"
     },
     {
       "LocusId": "POLG",

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch37.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch37.json.md5
@@ -1,1 +1,1 @@
-1e67ca88a588f67177ddaf73fd959f0b  variant_catalog_grch37.json
+4d45cde11ae6a0bdad1369334da7b203  variant_catalog_grch37.json

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch38.json
@@ -625,11 +625,12 @@
     {
       "VariantType": "Repeat",
       "LocusId": "PABPN1",
-      "LocusStructure": "(GCG)*",
-      "ReferenceRegion": "14:23321472-23321490",
+      "LocusStructure": "(GCN)*",
+      "ReferenceRegion": "14:23321472-23321502",
       "Disease": "OPMD",
-      "NormalMax": 6,
-      "PathologicMin": 9
+      "NormalMax": 10,
+      "PathologicMin": 11,
+      "Source": "GeneReviews Internet 2014-02-20"
     },
     {
       "VariantType": ["Repeat","Repeat"],

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_grch38.json.md5
@@ -1,1 +1,1 @@
-01c78d8d929d8e5a3dcbc94bfabc96de  variant_catalog_grch38.json
+307995ada2ab6ced673d0bbc6ebfbf81  variant_catalog_grch38.json

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg19.json
@@ -375,11 +375,12 @@
     {
         "VariantType": "Repeat",
         "LocusId": "PABPN1",
-        "LocusStructure": "(GCG)*",
-        "ReferenceRegion": "chr14:23790681-23790699",
+        "LocusStructure": "(GCN)*",
+        "ReferenceRegion": "chr14:23790681-23790711",
         "Disease": "OPMD",
-        "NormalMax": 6,
-        "PathologicMin": 9
+        "NormalMax": 10,
+        "PathologicMin": 11,
+        "Source": "GeneReviews Internet 2014-02-20"
     },
     {
       "LocusId": "POLG",

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg19.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg19.json.md5
@@ -1,1 +1,1 @@
-8f426eda929808a4f1063cd07194affc  variant_catalog_hg19.json
+e60d91f286dcfa89539e7732123e49b8  variant_catalog_hg19.json

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg38.json
@@ -625,11 +625,12 @@
     {
       "VariantType": "Repeat",
       "LocusId": "PABPN1",
-      "LocusStructure": "(GCG)*",
-      "ReferenceRegion": "chr14:23321472-23321490",
+      "LocusStructure": "(GCN)*",
+      "ReferenceRegion": "chr14:23321472-23321502",
       "Disease": "OPMD",
-      "NormalMax": 6,
-      "PathologicMin": 9
+      "NormalMax": 10,
+      "PathologicMin": 11,
+      "Source": "GeneReviews Internet 2014-02-20"
     },
     {
       "VariantType": ["Repeat","Repeat"],

--- a/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v3.1.2/variant_catalog_hg38.json.md5
@@ -1,1 +1,1 @@
-a0056dbf529e08d0e774293fe81251bf  variant_catalog_hg38.json
+6eadeb647520b89e03e24d7dac2f6329  variant_catalog_hg38.json


### PR DESCRIPTION
### This PR fixes:
Update PABPN1 entry - change to proper polyAla syntax (GCN)*, and hence update coords and pathogenic range. This now nicely harmonises with GeneReviews and other publications.

### How to test:
- Run ExpansionHunter and Stranger with the present variant catalog. Note PABPN1 annotation.

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
