### PR TITLE
feat(vcfanno_config): new flag

### DIFF
--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.9-.toml
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.9-.toml
@@ -1,0 +1,56 @@
+# TOML
+
+title = "Vcfanno configuration file" 
+
+[functions]
+file = "vcfanno_functions_-v1.0-.lua"
+
+[[annotation]]
+file="grch37_gnomad_reformated_-r2.1.1-.vcf.gz"
+fields = ["AF", "AF_popmax"]
+ops=["self", "self"]
+names=["GNOMADAF", "GNOMADAF_popmax"]
+
+[[annotation]]
+file="grch37_anon-swegen_str_nsphs_-1000samples-.vcf.gz"
+fields = ["AF", "AC_Hom", "AC_Het", "AC_Hemi"]
+ops=["self", "self", "self", "self"]
+names=["SWEGENAF", "SWEGENAAC_Hom", "SWEGENAAC_Het", "SWEGENAAC_Hemi"]
+
+[[annotation]]
+file="grch37_loqusdb_snv_indel_-2020-03-24-.vcf.gz"
+fields = ["Obs", "Hom"]
+ops=["self", "self"]
+names=["Obs", "Hom"]
+
+[[annotation]]
+file="grch37_genbank_haplogroup_-2015-08-01-.vcf.gz"
+fields = ["MTAF"]
+ops=["self"]
+names=["MTAF"]
+
+[[annotation]]
+file="grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz"
+names=["CADD"]
+ops=["mean"]
+columns=[6]
+
+[[annotation]]
+file="grch37_spidex_public_noncommercial_-v1.1-.tsv.gz"
+names=["SPIDEX"]
+ops=["mean"]
+columns=[6]
+
+[[annotation]]
+file="grch37_spliceai_scores_raw_snv_-v1.3-.vcf.gz"
+fields=["SpliceAI", "SpliceAI"]
+ops=["self", "lua:spliceai_max_score(vals)"]
+names=["SpliceAI", "SpliceAI_DS_max"]
+skip_split_and_normalize = true
+
+[[annotation]]
+file="grch37_spliceai_scores_raw_indel_-v1.3-.vcf.gz"
+fields=["SpliceAI", "SpliceAI"]
+ops=["self", "lua:spliceai_max_score(vals)"]
+names=["SpliceAI", "SpliceAI_DS_max"]
+skip_split_and_normalize = true

--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.9-.toml.md5
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.9-.toml.md5
@@ -1,0 +1,1 @@
+327b3ca17193ec77e05305ddf6b36be1  grch37_vcfanno_config_-v1.9-.toml


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a flag to the vcfanno config which tells MIP to skip split and normalize of reference

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
