### PR TITLE
Feature/update vcfanno toml

### DIFF
--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml
@@ -1,0 +1,43 @@
+# TOML
+
+title = "Vcfanno configuration file" 
+
+[functions]
+file="/home/proj/development/rare-disease/references_9.0/vcfanno_functions_-v1.0-.lua"
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_gnomad_reformated_-r2.1.1-.vcf.gz"
+fields = ["AF", "AF_popmax"]
+ops=["self", "self"]
+names=["GNOMADAF", "GNOMADAF_popmax"]
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_anon-swegen_str_nsphs_-1000samples-.vcf.gz"
+fields = ["AF", "AC_Hom", "AC_Het", "AC_Hemi"]
+ops=["self", "self", "self", "self"]
+names=["SWEGENAF", "SWEGENAAC_Hom", "SWEGENAAC_Het", "SWEGENAAC_Hemi"]
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_loqusdb_snv_indel_-2020-08-21-.vcf.gz"
+fields = ["Obs", "Hom"]
+ops=["self", "self"]
+names=["Obs", "Hom"]
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_genbank_haplogroup_-2015-08-01-.vcf.gz"
+fields = ["MTAF"]
+ops=["self"]
+names=["MTAF"]
+skip_normalize = true
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz"
+names=["CADD"]
+ops=["mean"]
+columns=[6]
+
+[[annotation]]
+file="/home/proj/development/rare-disease/references_9.0/grch37_spidex_public_noncommercial_-v1.1-.tsv.gz"
+names=["SPIDEX"]
+ops=["mean"]
+columns=[6]

--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml
@@ -3,41 +3,41 @@
 title = "Vcfanno configuration file" 
 
 [functions]
-file="/home/proj/development/rare-disease/references_9.0/vcfanno_functions_-v1.0-.lua"
+file="vcfanno_functions_-v1.0-.lua"
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_gnomad_reformated_-r2.1.1-.vcf.gz"
+file="grch37_gnomad_reformated_-r2.1.1-.vcf.gz"
 fields = ["AF", "AF_popmax"]
 ops=["self", "self"]
 names=["GNOMADAF", "GNOMADAF_popmax"]
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_anon-swegen_str_nsphs_-1000samples-.vcf.gz"
+file="grch37_anon-swegen_str_nsphs_-1000samples-.vcf.gz"
 fields = ["AF", "AC_Hom", "AC_Het", "AC_Hemi"]
 ops=["self", "self", "self", "self"]
 names=["SWEGENAF", "SWEGENAAC_Hom", "SWEGENAAC_Het", "SWEGENAAC_Hemi"]
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_loqusdb_snv_indel_-2020-08-21-.vcf.gz"
+file="grch37_loqusdb_snv_indel_-2020-08-21-.vcf.gz"
 fields = ["Obs", "Hom"]
 ops=["self", "self"]
 names=["Obs", "Hom"]
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_genbank_haplogroup_-2015-08-01-.vcf.gz"
+file="grch37_genbank_haplogroup_-2015-08-01-.vcf.gz"
 fields = ["MTAF"]
 ops=["self"]
 names=["MTAF"]
 skip_normalize = true
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz"
+file="grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz"
 names=["CADD"]
 ops=["mean"]
 columns=[6]
 
 [[annotation]]
-file="/home/proj/development/rare-disease/references_9.0/grch37_spidex_public_noncommercial_-v1.1-.tsv.gz"
+file="grch37_spidex_public_noncommercial_-v1.1-.tsv.gz"
 names=["SPIDEX"]
 ops=["mean"]
 columns=[6]

--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml.md5
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml.md5
@@ -1,0 +1,1 @@
+3f0c75bee9848f466e0bed7546238211  grch37_vcfanno_config_-v1.14-.toml

--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml.md5
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.14-.toml.md5
@@ -1,1 +1,1 @@
-3f0c75bee9848f466e0bed7546238211  grch37_vcfanno_config_-v1.14-.toml
+5f81a19eb98aeda692f33867e263d07b  grch37_vcfanno_config_-v1.14-.toml


### PR DESCRIPTION
### This PR adds | fixes:
- Updated vcfanno config to enable normalization check for genbank haplogroup vcf 

Related to changes made [here](https://github.com/Clinical-Genomics/MIP/pull/1853)

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
