### PR TITLE
Update STR ref BEAN1 link

### DIFF
--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -293,7 +293,7 @@
         "DisplayRU": "TGGAA",
         "SourceDisplay": "Sato et al AJHG 2009",
         "Source": "PubMed",
-        "SourceId": "7603564",
+        "SourceId": "19878914",
         "LocusStructure": "(TGGAA)*TAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAA",
         "ReferenceRegion": "16:66524302-66524356",
         "Disease": "SCA31",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json.md5
@@ -1,1 +1,1 @@
-207b2ae25e304897f53651a0a1b3528b  variant_catalog_grch37.json
+52e6f57f9bf1b9f78b23aa5aeaeb1417 variant_catalog_grch37.json

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -316,7 +316,7 @@
         "DisplayRU": "TGGAA",
         "SourceDisplay": "Sato et al AJHG 2009",
         "Source": "PubMed",
-        "SourceId": "7603564",
+        "SourceId": "19878914",
         "LocusStructure": "(TGGAA)*TAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAA",
         "ReferenceRegion": "16:66490399-66490453",
         "Disease": "SCA31",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json.md5
@@ -1,1 +1,1 @@
-79a1c427ad2af3dc670c20e746da7a5f  variant_catalog_grch38.json
+d3abf65a5f90081262538eaadca3fcec variant_catalog_grch38.json

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -293,7 +293,7 @@
         "DisplayRU": "TGGAA",
         "SourceDisplay": "Sato et al AJHG 2009",
         "Source": "PubMed",
-        "SourceId": "7603564",
+        "SourceId": "19878914",
         "LocusStructure": "(TGGAA)*TAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAA",
         "ReferenceRegion": "chr16:66524302-66524356",
         "Disease": "SCA31",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json.md5
@@ -1,1 +1,1 @@
-8fb0b00b85ef0deea24dbee8459ccb42  variant_catalog_hg19.json
+c76ffa21724ef6f2cd80b5d625b194d4 variant_catalog_hg19.json

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -316,7 +316,7 @@
         "DisplayRU": "TGGAA",
         "SourceDisplay": "Sato et al AJHG 2009",
         "Source": "PubMed",
-        "SourceId": "7603564",
+        "SourceId": "19878914",
         "LocusStructure": "(TGGAA)*TAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAA",
         "ReferenceRegion": "chr16:66490399-66490453",
         "Disease": "SCA31",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json.md5
@@ -1,1 +1,1 @@
-62833ae8bac9bd218bc98df8aab81498  variant_catalog_hg38.json
+4ffc7c0a3a3ada9a0e490d5db70707f7 variant_catalog_hg38.json


### PR DESCRIPTION
### This PR adds | fixes:

Reference PubMed id was pointing to the wrong paper for BEAN1 - see https://github.com/Clinical-Genomics/scout/issues/2490 

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
