### PR TITLE
updates rankmodel files for mip

### DIFF
--- a/rare-disease/rank_model/rank_model_-v1.33-.ini
+++ b/rare-disease/rank_model/rank_model_-v1.33-.ini
@@ -20,10 +20,10 @@
 
  [[conservation]]
    category_aggregation = sum
- 
+
  [[variant_call_quality_filter]]
    category_aggregation = sum
- 
+
  [[deleteriousness]]
    category_aggregation = max
 
@@ -37,7 +37,7 @@
   category = splicing
   csq_key = MaxEntScan_alt
   data_type = float
-  description = MaxEntScan alternative score for naitive 
+  description = MaxEntScan alternative score for naitive
   field = INFO
   info_key = CSQ
   record_rule = max
@@ -192,7 +192,7 @@
     score = 0
     lower = -1
     upper = 1
-  
+
   [[medium_pos]]
     score = 3
     lower = 1
@@ -340,6 +340,11 @@
   [[low_qual]]
     score = -5
     lower = 0
+    upper = 10
+
+  [[medium_qual]]
+    score = -2
+    lower = 10
     upper = 20
 
   [[high_qual]]
@@ -395,12 +400,12 @@
     score = -12
     lower = 0.02
     upper = 1.1
-  
+
   [[intermediate]]
     score = 1
     lower = 0.005
     upper = 0.02
-  
+
   [[rare]]
     score = 2
     lower = 0.0005
@@ -657,7 +662,7 @@
     score = 10
     priority = 6
     string = 'transcript_ablation'
-  
+
   [[initiator_codon_variant]]
     score = 9
     priority = 5
@@ -851,6 +856,11 @@
     score = 3
     priority = 1
     string = 'PASS'
+  
+  [[dot]]
+    score = 3
+    priority = 2
+    string = '.'
 
 [dbnsfp_gerp++_rs]
   category = conservation
@@ -869,7 +879,7 @@
     score = 1
     lower = 2
     upper = 10
-  
+
   [[not_conserved]]
     score = 0
     lower = 0
@@ -892,7 +902,7 @@
     score = 1
     lower = 0.8
     upper = 100
-  
+
   [[not_conserved]]
     score = 0
     lower = 0
@@ -915,7 +925,7 @@
     score = 1
     lower = 2.5
     upper = 100
-  
+
   [[not_conserved]]
     score = 0
     lower = 0
@@ -937,7 +947,7 @@
     score = 0
     lower = 0
     upper = 10
-  
+
   [[medium]]
     score = 2
     lower = 10
@@ -967,7 +977,7 @@
   info_key = CSQ
   record_rule = max
   separators = '/',",",
-  
+
   [[not_provided]]
     score = 0
     priority = 0
@@ -992,7 +1002,7 @@
   [[Likely_benign]]
     score = 0
     priority = 1
-    string = 'Likely_benign'  
+    string = 'Likely_benign'
 
   [[Benign]]
     score = -1
@@ -1008,7 +1018,7 @@
     score = 5
     priority = 3
     string = 'Pathogenic'
-  
+
 [clnrevstat]
   category = clinical_significance
   csq_key = CLINVAR_CLNREVSTAT

--- a/rare-disease/rank_model/rank_model_-v1.33-.ini.md5
+++ b/rare-disease/rank_model/rank_model_-v1.33-.ini.md5
@@ -1,1 +1,1 @@
-872621c97039380f205c8e1b46a0723a  rare-disease/rank_model/rank_model_-v1.33-.ini
+0725d4e5171606364b3e4f04173fdbfa  rare-disease/rank_model/rank_model_-v1.33-.ini


### PR DESCRIPTION
### This PR adds | fixes:
- updates the existing rankmodel file version 1.33

Rather than adding a new one, I updated the latest rankmodel file for mip which haven't been used in production yet. 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Run the release candidate of MIP with the updated rankmodel file 

### Expected outcome:
- [ ] Variants are scored.
- [ ] Results logged here: https://github.com/Clinical-Genomics/validations/pull/21

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
