### PR TITLE
Sync with STRipy

### DIFF
--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -927,7 +927,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "13:100637703-100637747",
+        "ReferenceRegion": "13:100637702-100637747",
         "Disease": "HPE5",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -193,7 +193,7 @@
         "LocusId": "C9ORF72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
-        "DisplayRU": "GGCCCC",
+        "DisplayRU": "GGGGCC",
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -942,7 +942,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "X:136648986-136649015",
+        "ReferenceRegion": "X:136648985-136649015",
         "Disease": "VACTERLX",
         "NormalMax": 10,
         "PathologicMin": 12

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -651,7 +651,7 @@
         "Source": "PubMed",
         "SourceId": "32413282",
         "LocusStructure": "(CCG)*",
-        "ReferenceRegion": "19:14606854-14606886",
+        "ReferenceRegion": "19:14606853-14606886",
         "Disease": "OPDM2",
         "NormalMax": 32,
         "PathologicMin": 73

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -531,7 +531,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27239544-27239585",
+        "ReferenceRegion": "7:27239543-27239585",
         "Disease": "HFGS",
         "NormalMax": 14,
         "PathologicMin": 22
@@ -546,7 +546,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27239445-27239480",
+        "ReferenceRegion": "7:27239444-27239480",
         "Disease": "HFGS",
         "NormalMax": 12,
         "PathologicMin": 18
@@ -561,7 +561,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27239298-27239351",
+        "ReferenceRegion": "7:27239297-27239351",
         "Disease": "HFGS",
         "NormalMax": 18,
         "PathologicMin": 24

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -990,13 +990,10 @@
         "SourceDisplay": "Research only - contact CMMS KUH regarding findings",
         "Source": "Expert",
         "SourceId": "CMMS",
-        "LocusStructure": "(CTG)*TTG(CTG)*",
-        "VariantType": ["Repeat","Repeat"],
-        "VariantId": ["POLG_I", "POLG_II"],
-        "ReferenceRegion": ["15:89876821-89876826",
-                            "15:89876830-89876859"],
-        "NormalMax": 15,
-        "PathologicMin": 10000,
-        "PathologicRegion": "15:89876830-89876859"
+        "LocusStructure": "(CTG)*",
+        "VariantType": "Repeat",
+        "ReferenceRegion": "15:89876820-89876859",
+        "NormalMax": 16,
+        "PathologicMin": 10000
     }
 ]

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -138,11 +138,11 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCT)*",
-        "ReferenceRegion": "14:92537353-92537386",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "14:92537354-92537384",
         "Disease": "MJD",
         "NormalMax": 44,
-        "PathologicMin": 60
+        "PathologicMin": 56
     },
     {
         "VariantType": "Repeat",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -145,7 +145,6 @@
         "PathologicMin": 56
     },
     {
-        "VariantType": "Repeat",
         "LocusId": "ATXN7",
         "HGNCId": 10560,
         "InheritanceMode": "AD",
@@ -153,25 +152,13 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "SweGenMean": 10.31,
-        "SweGenStd": 1.285,
-        "LocusStructure": "(GCA)*(GCC)+",
-        "ReferenceRegion": [
-            "3:63898360-63898390",
-            "3:63898390-63898402"
-        ],
-        "VariantType": [
-            "Repeat",
-            "Repeat"
-        ],
-        "VariantId": [
-            "ATXN7",
-            "ATXN7_GCC"
-        ],
+        "LocusStructure": "(CAG)*",
+        "ReferenceRegion": "3:63898361-63898391",
+        "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
         "PathologicMin": 36,
-        "PathologicRegion": "3:63898360-63898390"
+        "PathologicRegion": "3:63898361-63898391"
     },
     {
         "LocusId": "ATXN8OS",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -911,8 +911,8 @@
         "SourceDisplay": "LaCroix et al (2018) AJHG 104(1) 35-44",
         "Source": "PubMed",
         "SourceId": "30554721",
-        "LocusStructure": "(GGC)*",
-        "ReferenceRegion": "16:17564765-17564778",
+        "LocusStructure": "(GCC)*",
+        "ReferenceRegion": "16:17564764-17564779",
         "Disease": "DBQD2",
         "NormalMax": 20,
         "PathologicMin": 70

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -488,7 +488,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "3:138664863-138664904",
+        "ReferenceRegion": "3:138664862-138664904",
         "Disease": "BPES",
         "NormalMax": 14,
         "PathologicMin": 15

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -976,7 +976,7 @@
         "LocusStructure": "(GCA)*",
         "ReferenceRegion": "2:191745598-191745646",
         "Disease": "GDPAG",
-        "NormalMax": 20,
+        "NormalMax": 26,
         "PathologicMin": 90
     },
     {

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -11,7 +11,7 @@
         "SweGenMean": 23.87,
         "SweGenStd": 7.523,
         "LocusStructure": "(GCC)*",
-        "ReferenceRegion": "X:147582151-147582211",
+        "ReferenceRegion": "X:147582158-147582203",
         "Disease": "Fraxe",
         "NormalMax": 39,
         "PathologicMin": 200
@@ -30,7 +30,7 @@
         "LocusStructure": "(GCA)*",
         "ReferenceRegion": "X:66765158-66765227",
         "Disease": "SBMA",
-        "NormalMax": 34,
+        "NormalMax": 35,
         "PathologicMin": 38
     },
     {
@@ -46,7 +46,7 @@
         "ReferenceRegion": "X:25031766-25031814",
         "Disease": "EIEE",
         "NormalMax": 16,
-        "PathologicMin": 17
+        "PathologicMin": 18
     },
     {
         "VariantType": "Repeat",
@@ -75,7 +75,7 @@
         "SweGenMean": 17.99,
         "SweGenStd": 3.053,
         "LocusStructure": "(CAG)*",
-        "ReferenceRegion": "12:7045879-7045936",
+        "ReferenceRegion": "12:7045891-7045936",
         "Disease": "DRPLA",
         "NormalMax": 35,
         "PathologicMin": 48
@@ -712,7 +712,7 @@
         "SweGenMean": 26.33,
         "SweGenStd": 11.88,
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "4:41747988-41748049",
+        "ReferenceRegion": "4:41747988-41748048",
         "NormalMax": 20,
         "PathologicMin": 25
     },
@@ -803,7 +803,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "6:45390488-45390538",
+        "ReferenceRegion": "6:45390487-45390538",
         "Disease": "CCD",
         "NormalMax": 17,
         "PathologicMin": 20
@@ -833,7 +833,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1438",
         "LocusStructure": "(GCA)*",
-        "ReferenceRegion": "6:170870994-170871109",
+        "ReferenceRegion": "6:170870995-170871103",
         "Disease": "SCA17",
         "SweGenMean": 36.24,
         "SweGenStd": 2.293,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -364,6 +364,21 @@
         "PathologicMin": 31
     },
     {
+        "LocusId": "DMD",
+        "HGNCId": 2933,
+        "InheritanceMode": "AD",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Kekou et al 2016 Mol Cell Probes 30(4):254-260",
+        "Source": "PubMed",
+        "SourceId": "27417533",
+        "LocusStructure": "(GAA)*",
+        "ReferenceRegion": "X:31302674-31302722",
+        "VariantType": "Repeat",
+        "Disease": "DMD",
+        "NormalMax": 34,
+        "PathologicMin": 59
+    },
+    {
         "VariantType": "Repeat",
         "LocusId": "DIP2B",
         "HGNCId": 29284,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -8,9 +8,7 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "SweGenMean": 23.87,
-        "SweGenStd": 7.523,
-        "LocusStructure": "(GCC)*",
+        "LocusStructure": "(CCG)*",
         "ReferenceRegion": "X:147582158-147582203",
         "Disease": "Fraxe",
         "NormalMax": 39,
@@ -108,11 +106,11 @@
         "SourceId": "NBK1184",
         "SweGenMean": 31.17,
         "SweGenStd": 2.022,
-        "LocusStructure": "(TGC)*",
-        "ReferenceRegion": "6:16327864-16327954",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "6:16327866-16327953",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 45
+        "PathologicMin": 40,
     },
     {
         "VariantType": "Repeat",
@@ -125,11 +123,11 @@
         "SourceId": "NBK1275",
         "SweGenMean": 22.11,
         "SweGenStd": 1.353,
-        "LocusStructure": "(GCT)*",
+        "LocusStructure": "(CTG)*",
         "ReferenceRegion": "12:112036753-112036822",
         "Disease": "SCA2",
         "NormalMax": 31,
-        "PathologicMin": 37
+        "PathologicMin": 33
     },
     {
         "VariantType": "Repeat",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -110,7 +110,7 @@
         "ReferenceRegion": "6:16327866-16327953",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 40,
+        "PathologicMin": 40
     },
     {
         "VariantType": "Repeat",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -576,7 +576,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "2:176957787-176957831",
+        "ReferenceRegion": "2:176957786-176957831",
         "Disease": "SDTY5",
         "NormalMax": 15,
         "PathologicMin": 22

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -787,7 +787,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "2:176093059-176093103",
+        "ReferenceRegion": "2:176093058-176093103",
         "Disease": "SDTY5",
         "NormalMax": 15,
         "PathologicMin": 22

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1126,8 +1126,8 @@
         "SourceDisplay": "LaCroix et al (2018) AJHG 104(1) 35-44",
         "Source": "PubMed",
         "SourceId": "30554721",
-        "LocusStructure": "(GGC)*",
-        "ReferenceRegion": "16:17470908-17470921",
+        "LocusStructure": "(GCC)*",
+        "ReferenceRegion": "16:17470907-17470922",
         "Disease": "DBQD2",
         "NormalMax": 20,
         "PathologicMin": 70

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -858,7 +858,7 @@
         "Source": "PubMed",
         "SourceId": "32413282",
         "LocusStructure": "(CCG)*",
-        "ReferenceRegion": "19:14496042-14496074",
+        "ReferenceRegion": "19:14496041-14496074",
         "Disease": "OPDM2",
         "NormalMax": 32,
         "PathologicMin": 73

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -127,12 +127,12 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCT)*",
-        "ReferenceRegion": "14:92071009-92071042",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "14:92071010-92071040",
         "VariantType": "Repeat",
         "Disease": "MJD",
         "NormalMax": 44,
-        "PathologicMin": 60
+        "PathologicMin": 56
     },
     {
         "LocusId": "ATXN7",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1142,7 +1142,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "13:99985449-99985493",
+        "ReferenceRegion": "13:99985448-99985493",
         "Disease": "HPE5",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -142,19 +142,9 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCA)*(GCC)+",
-        "ReferenceRegion": [
-            "3:63912684-63912714",
-            "3:63912714-63912726"
-        ],
-        "VariantId": [
-            "ATXN7",
-            "ATXN7_GCC"
-        ],
-        "VariantType": [
-            "Repeat",
-            "Repeat"
-        ],
+        "LocusStructure": "(CAG)*",
+        "ReferenceRegion": "3:63912684-63912714",
+        "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
         "PathologicMin": 36,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -742,7 +742,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27199925-27199966",
+        "ReferenceRegion": "7:27199924-27199966",
         "Disease": "HFGS",
         "NormalMax": 14,
         "PathologicMin": 22
@@ -757,7 +757,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27199826-27199861",
+        "ReferenceRegion": "7:27199825-27199861",
         "Disease": "HFGS",
         "NormalMax": 12,
         "PathologicMin": 18
@@ -772,7 +772,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "7:27199679-27199732",
+        "ReferenceRegion": "7:27199678-27199732",
         "Disease": "HFGS",
         "NormalMax": 18,
         "PathologicMin": 24

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1066,7 +1066,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "22:19766763-19766807",
+        "ReferenceRegion": "22:19766762-19766807",
         "Disease": "TOF",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1196,7 +1196,7 @@
     },
 
     {
-      "VariantType": ["Repeat","Repeat"],
+      "VariantType": "Repeat",
       "LocusId": "POLG",
       "HGNCId": 9179,
       "DisplayRU": "CTG",
@@ -1205,12 +1205,9 @@
       "SourceDisplay": "Research only - contact CMMS KUH regarding findings",
       "Source": "Expert",
       "SourceId": "CMMS",    
-      "VariantId": ["POLG_I", "POLG_II"],
-      "LocusStructure": "(CTG)*TTG(CTG)*",
-      "ReferenceRegion": ["15:89333590-89333595",
-                          "15:89333599-89333628"],
-      "NormalMax": 15,
-      "PathologicMin": 10000,
-      "PathologicRegion": "15:89333599-89333628"
+      "LocusStructure": "(CTG)*",
+      "ReferenceRegion": "15:89333580-89333628",
+      "NormalMax": 16,
+      "PathologicMin": 10000
     }
 ]

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -701,7 +701,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "3:138946021-138946062",
+        "ReferenceRegion": "3:138946020-138946062",
         "Disease": "BPES",
         "NormalMax": 14,
         "PathologicMin": 15

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -180,7 +180,7 @@
         "LocusId": "C9ORF72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
-        "DisplayRU": "GGCCCC",
+        "DisplayRU": "GGGGCC",
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -7,7 +7,7 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCC)*",
+        "LocusStructure": "(CCG)*",
         "ReferenceRegion": "X:148500638-148500683",
         "VariantType": "Repeat",
         "Disease": "Fraxe",
@@ -97,12 +97,12 @@
         "SourceDisplay": "GeneReviews Internet 2017-06-22",
         "Source": "GeneReviews",
         "SourceId": "NBK1184",
-        "LocusStructure": "(TGC)*",
-        "ReferenceRegion": "6:16327633-16327723",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "6:16327635-16327722",
         "VariantType": "Repeat",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 45
+        "PathologicMin": 40,
     },
     {
         "LocusId": "ATXN2",
@@ -112,12 +112,12 @@
         "SourceDisplay": "GeneReviews Internet 2019-02-14",
         "Source": "GeneReviews",
         "SourceId": "NBK1275",
-        "LocusStructure": "(GCT)*",
+        "LocusStructure": "(CTG)*",
         "ReferenceRegion": "12:111598949-111599018",
         "VariantType": "Repeat",
         "Disease": "SCA2",
         "NormalMax": 31,
-        "PathologicMin": 37
+        "PathologicMin": 33
     },
     {
         "LocusId": "ATXN3",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1171,7 +1171,7 @@
         "SourceDisplay": "Tazelaar et al (2019) Neurobiol Aging 74 234.e9-234.e15",
         "Source": "PubMed",
         "SourceId": "30342764",
-        "LocusStructure": "(CGC)*",
+        "LocusStructure": "(GCG)*",
         "ReferenceRegion": "15:22786677-22786701",
         "Disease": "ALS - susceptibility to",
         "NormalMax": 8,
@@ -1190,7 +1190,7 @@
       "LocusStructure": "(GCA)*",
       "ReferenceRegion": "2:190880872-190880920",
       "Disease": "GDPAG",
-      "NormalMax": 20,
+      "NormalMax": 26,
       "PathologicMin": 90
     },
     {

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -8,7 +8,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCC)*",
-        "ReferenceRegion": "X:148500631-148500691",
+        "ReferenceRegion": "X:148500638-148500683",
         "VariantType": "Repeat",
         "Disease": "Fraxe",
         "NormalMax": 39,
@@ -26,7 +26,7 @@
         "ReferenceRegion": "X:67545316-67545385",
         "VariantType": "Repeat",
         "Disease": "SBMA",
-        "NormalMax": 34,
+        "NormalMax": 35,
         "PathologicMin": 38
     },
     {
@@ -42,7 +42,7 @@
         "ReferenceRegion": "X:25013649-25013697",
         "Disease": "EIEE",
         "NormalMax": 16,
-        "PathologicMin": 17
+        "PathologicMin": 18
     },
     {
         "VariantType": "Repeat",
@@ -68,7 +68,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
-        "ReferenceRegion": "12:6936716-6936773",
+        "ReferenceRegion": "12:6936728-6936773",
         "VariantType": "Repeat",
         "Disease": "DRPLA",
         "NormalMax": 35,
@@ -925,7 +925,7 @@
         "SourceId": "NBK1427",
         "Disease": "CCHS",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "4:41745971-41746032",
+        "ReferenceRegion": "4:41745971-41746031",
         "VariantType": "Repeat",
         "NormalMax": 20,
         "PathologicMin": 25,
@@ -1017,7 +1017,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "6:45422751-45422801",
+        "ReferenceRegion": "6:45422750-45422801",
         "Disease": "CCD",
         "NormalMax": 17,
         "PathologicMin": 20
@@ -1046,7 +1046,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1438",
         "LocusStructure": "(GCA)*",
-        "ReferenceRegion": "6:170561906-170562017",
+        "ReferenceRegion": "6:170561907-170562015",
         "VariantType": "Repeat",
         "Disease": "SCA17",
         "NormalMax": 40,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -1157,7 +1157,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "X:137566827-137566856",
+        "ReferenceRegion": "X:137566826-137566856",
         "Disease": "VACTERLX",
         "NormalMax": 10,
         "PathologicMin": 12

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -102,7 +102,7 @@
         "VariantType": "Repeat",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 40,
+        "PathologicMin": 40
     },
     {
         "LocusId": "ATXN2",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -387,7 +387,6 @@
         "NormalMax": 16,
         "PathologicMin": 31
     },
-
     {
         "LocusId": "DIP2B",
         "HGNCId": 29284,
@@ -403,6 +402,21 @@
         "NormalMax": 24,
         "PathologicMin": 270,
         "Disease": "FRA12A"
+    },
+   {
+        "LocusId": "DMD",
+        "HGNCId": 2933,
+        "InheritanceMode": "AD",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Kekou et al 2016 Mol Cell Probes 30(4):254-260",
+        "Source": "PubMed",
+        "SourceId": "27417533",
+        "LocusStructure": "(GAA)*",
+        "ReferenceRegion": "X:31284557-31284605",
+        "VariantType": "Repeat",
+        "Disease": "DMD",
+        "NormalMax": 34,
+        "PathologicMin": 59
     },
     {
         "LocusId": "DMPK",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -990,13 +990,10 @@
         "SourceDisplay": "Research only - contact CMMS KUH regarding findings",
         "Source": "Expert",
         "SourceId": "CMMS",
-        "LocusStructure": "(CTG)*TTG(CTG)*",
-        "VariantType": ["Repeat","Repeat"],
-        "VariantId": ["POLG_I", "POLG_II"],
-        "ReferenceRegion": ["chr15:89876821-89876826",
-                            "chr15:89876830-89876859"],
-        "NormalMax": 15,
-        "PathologicMin": 10000,
-        "PathologicRegion": "chr15:89876830-89876859"
+        "LocusStructure": "(CTG)*",
+        "VariantType": "Repeat",
+        "ReferenceRegion": "chr15:89876820-89876859",
+        "NormalMax": 16,
+        "PathologicMin": 10000
     }
 ]

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -193,7 +193,7 @@
         "LocusId": "C9ORF72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
-        "DisplayRU": "GGCCCC",
+        "DisplayRU": "GGGGCC",
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -138,11 +138,11 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCT)*",
-        "ReferenceRegion": "chr14:92537353-92537386",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "chr14:92537354-92537384",
         "Disease": "MJD",
         "NormalMax": 44,
-        "PathologicMin": 60
+        "PathologicMin": 56
     },
     {
         "VariantType": "Repeat",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -531,7 +531,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27239544-27239585",
+        "ReferenceRegion": "chr7:27239543-27239585",
         "Disease": "HFGS",
         "NormalMax": 14,
         "PathologicMin": 22
@@ -546,7 +546,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27239445-27239480",
+        "ReferenceRegion": "chr7:27239444-27239480",
         "Disease": "HFGS",
         "NormalMax": 12,
         "PathologicMin": 18
@@ -561,7 +561,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27239298-27239351",
+        "ReferenceRegion": "chr7:27239297-27239351",
         "Disease": "HFGS",
         "NormalMax": 18,
         "PathologicMin": 24

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -911,8 +911,8 @@
         "SourceDisplay": "LaCroix et al (2018) AJHG 104(1) 35-44",
         "Source": "PubMed",
         "SourceId": "30554721",
-        "LocusStructure": "(GGC)*",
-        "ReferenceRegion": "chr16:17564765-17564778",
+        "LocusStructure": "(GCC)*",
+        "ReferenceRegion": "chr16:17564764-17564779",
         "Disease": "DBQD2",
         "NormalMax": 20,
         "PathologicMin": 70

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -8,9 +8,7 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "SweGenMean": 23.87,
-        "SweGenStd": 7.523,
-        "LocusStructure": "(GCC)*",
+        "LocusStructure": "(CCG)*",
         "ReferenceRegion": "chrX:147582158-147582203",
         "Disease": "Fraxe",
         "NormalMax": 39,
@@ -108,11 +106,11 @@
         "SourceId": "NBK1184",
         "SweGenMean": 31.17,
         "SweGenStd": 2.022,
-        "LocusStructure": "(TGC)*",
-        "ReferenceRegion": "chr6:16327864-16327954",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "chr6:16327866-16327953",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 45
+        "PathologicMin": 40
     },
     {
         "VariantType": "Repeat",
@@ -125,11 +123,11 @@
         "SourceId": "NBK1275",
         "SweGenMean": 22.11,
         "SweGenStd": 1.353,
-        "LocusStructure": "(GCT)*",
+        "LocusStructure": "(CTG)*",
         "ReferenceRegion": "chr12:112036753-112036822",
         "Disease": "SCA2",
         "NormalMax": 31,
-        "PathologicMin": 37
+        "PathologicMin": 33
     },
     {
         "VariantType": "Repeat",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -651,7 +651,7 @@
         "Source": "PubMed",
         "SourceId": "32413282",
         "LocusStructure": "(CCG)*",
-        "ReferenceRegion": "chr19:14606854-14606886",
+        "ReferenceRegion": "chr19:14606853-14606886",
         "Disease": "OPDM2",
         "NormalMax": 32,
         "PathologicMin": 73

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -576,7 +576,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr2:176957787-176957831",
+        "ReferenceRegion": "chr2:176957786-176957831",
         "Disease": "SDTY5",
         "NormalMax": 15,
         "PathologicMin": 22

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -11,7 +11,7 @@
         "SweGenMean": 23.87,
         "SweGenStd": 7.523,
         "LocusStructure": "(GCC)*",
-        "ReferenceRegion": "chrX:147582151-147582211",
+        "ReferenceRegion": "chrX:147582158-147582203",
         "Disease": "Fraxe",
         "NormalMax": 39,
         "PathologicMin": 200
@@ -30,7 +30,7 @@
         "LocusStructure": "(GCA)*",
         "ReferenceRegion": "chrX:66765158-66765227",
         "Disease": "SBMA",
-        "NormalMax": 34,
+        "NormalMax": 35,
         "PathologicMin": 38
     },
     {
@@ -46,7 +46,7 @@
         "ReferenceRegion": "chrX:25031766-25031814",
         "Disease": "EIEE",
         "NormalMax": 16,
-        "PathologicMin": 17
+        "PathologicMin": 18
     },
     {
         "VariantType": "Repeat",
@@ -75,7 +75,7 @@
         "SweGenMean": 17.99,
         "SweGenStd": 3.053,
         "LocusStructure": "(CAG)*",
-        "ReferenceRegion": "chr12:7045879-7045936",
+        "ReferenceRegion": "chr12:7045891-7045936",
         "Disease": "DRPLA",
         "NormalMax": 35,
         "PathologicMin": 48
@@ -712,7 +712,7 @@
         "SweGenMean": 26.33,
         "SweGenStd": 11.88,
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr4:41747988-41748049",
+        "ReferenceRegion": "chr4:41747988-41748048",
         "NormalMax": 20,
         "PathologicMin": 25
     },
@@ -803,7 +803,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr6:45390488-45390538",
+        "ReferenceRegion": "chr6:45390487-45390538",
         "Disease": "CCD",
         "NormalMax": 17,
         "PathologicMin": 20
@@ -833,7 +833,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1438",
         "LocusStructure": "(GCA)*",
-        "ReferenceRegion": "chr6:170870994-170871109",
+        "ReferenceRegion": "chr6:170870995-170871103",
         "Disease": "SCA17",
         "SweGenMean": 36.24,
         "SweGenStd": 2.293,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -927,7 +927,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr13:100637703-100637747",
+        "ReferenceRegion": "chr13:100637702-100637747",
         "Disease": "HPE5",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -130,7 +130,6 @@
         "PathologicMin": 33
     },
     {
-        "VariantType": "Repeat",
         "LocusId": "ATXN3",
         "HGNCId": 7106,
         "InheritanceMode": "AD",
@@ -140,12 +139,12 @@
         "SourceId": "NBK535148",
         "LocusStructure": "(CTG)*",
         "ReferenceRegion": "chr14:92537354-92537384",
+        "VariantType": "Repeat",
         "Disease": "MJD",
         "NormalMax": 44,
         "PathologicMin": 56
     },
     {
-        "VariantType": "Repeat",
         "LocusId": "ATXN7",
         "HGNCId": 10560,
         "InheritanceMode": "AD",
@@ -153,25 +152,13 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "SweGenMean": 10.31,
-        "SweGenStd": 1.285,
-        "LocusStructure": "(GCA)*(GCC)+",
-        "ReferenceRegion": [
-            "chr3:63898360-63898390",
-            "chr3:63898390-63898402"
-        ],
-        "VariantType": [
-            "Repeat",
-            "Repeat"
-        ],
-        "VariantId": [
-            "ATXN7",
-            "ATXN7_GCC"
-        ],
+        "LocusStructure": "(CAG)*",
+        "ReferenceRegion": "chr3:63898361-63898391",
+        "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
         "PathologicMin": 36,
-        "PathologicRegion": "chr3:63898360-63898390"
+        "PathologicRegion": "chr3:63898361-63898391"
     },
     {
         "LocusId": "ATXN8OS",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -942,7 +942,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chrX:136648986-136649015",
+        "ReferenceRegion": "chrX:136648985-136649015",
         "Disease": "VACTERLX",
         "NormalMax": 10,
         "PathologicMin": 12

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -488,7 +488,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr3:138664863-138664904",
+        "ReferenceRegion": "chr3:138664862-138664904",
         "Disease": "BPES",
         "NormalMax": 14,
         "PathologicMin": 15

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -381,6 +381,21 @@
         "PathologicMin": 270
     },
     {
+        "LocusId": "DMD",
+        "HGNCId": 2933,
+        "InheritanceMode": "AD",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Kekou et al 2016 Mol Cell Probes 30(4):254-260",
+        "Source": "PubMed",
+        "SourceId": "27417533",
+        "LocusStructure": "(GAA)*",
+        "ReferenceRegion": "chrX:31302674-31302722",
+        "VariantType": "Repeat",
+        "Disease": "DMD",
+        "NormalMax": 34,
+        "PathologicMin": 59
+    },
+    {
         "VariantType": "Repeat",
         "LocusId": "DMPK",
         "HGNCId": 2933,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -976,7 +976,7 @@
         "LocusStructure": "(GCA)*",
         "ReferenceRegion": "chr2:191745598-191745646",
         "Disease": "GDPAG",
-        "NormalMax": 20,
+        "NormalMax": 26,
         "PathologicMin": 90
     },
     {

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -850,7 +850,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr22:19754286-19754330",
+        "ReferenceRegion": "chr22:19754285-19754330",
         "Disease": "TOF",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1126,8 +1126,8 @@
         "SourceDisplay": "LaCroix et al (2018) AJHG 104(1) 35-44",
         "Source": "PubMed",
         "SourceId": "30554721",
-        "LocusStructure": "(GGC)*",
-        "ReferenceRegion": "chr16:17470908-17470921",
+        "LocusStructure": "(GCC)*",
+        "ReferenceRegion": "chr16:17470907-17470922",
         "Disease": "DBQD2",
         "NormalMax": 20,
         "PathologicMin": 70

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -701,7 +701,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr3:138946021-138946062",
+        "ReferenceRegion": "chr3:138946020-138946062",
         "Disease": "BPES",
         "NormalMax": 14,
         "PathologicMin": 15

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -858,7 +858,7 @@
         "Source": "PubMed",
         "SourceId": "32413282",
         "LocusStructure": "(CCG)*",
-        "ReferenceRegion": "chr19:14496042-14496074",
+        "ReferenceRegion": "chr19:14496041-14496074",
         "Disease": "OPDM2",
         "NormalMax": 32,
         "PathologicMin": 73

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -127,12 +127,12 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCT)*",
-        "ReferenceRegion": "chr14:92071009-92071042",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "chr14:92071010-92071040",
         "VariantType": "Repeat",
         "Disease": "MJD",
         "NormalMax": 44,
-        "PathologicMin": 60
+        "PathologicMin": 56
     },
     {
         "LocusId": "ATXN7",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1207,6 +1207,6 @@
       "LocusStructure": "(CTG)*",
       "ReferenceRegion": "chr15:89833580-89833628",
       "NormalMax": 16,
-      "PathologicMin": 10000,
+      "PathologicMin": 10000
     }
 ]

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -387,7 +387,6 @@
         "NormalMax": 16,
         "PathologicMin": 31
     },
-
     {
         "LocusId": "DIP2B",
         "HGNCId": 29284,
@@ -403,6 +402,21 @@
         "NormalMax": 24,
         "PathologicMin": 270,
         "Disease": "FRA12A"
+    },
+    {
+        "LocusId": "DMD",
+        "HGNCId": 2933,
+        "InheritanceMode": "AD",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Kekou et al 2016 Mol Cell Probes 30(4):254-260",
+        "Source": "PubMed",
+        "SourceId": "27417533",
+        "LocusStructure": "(GAA)*",
+        "ReferenceRegion": "chrX:31284557-31284605",
+        "VariantType": "Repeat",
+        "Disease": "DMD",
+        "NormalMax": 34,
+        "PathologicMin": 59
     },
     {
         "LocusId": "DMPK",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1157,7 +1157,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chrX:137566827-137566856",
+        "ReferenceRegion": "chrX:137566826-137566856",
         "Disease": "VACTERLX",
         "NormalMax": 10,
         "PathologicMin": 12

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -8,7 +8,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCC)*",
-        "ReferenceRegion": "chrX:148500631-148500691",
+        "ReferenceRegion": "chrX:148500638-148500683",
         "VariantType": "Repeat",
         "Disease": "Fraxe",
         "NormalMax": 39,
@@ -26,7 +26,7 @@
         "ReferenceRegion": "chrX:67545316-67545385",
         "VariantType": "Repeat",
         "Disease": "SBMA",
-        "NormalMax": 34,
+        "NormalMax": 35,
         "PathologicMin": 38
     },
     {
@@ -42,7 +42,7 @@
         "ReferenceRegion": "chrX:25013649-25013697",
         "Disease": "EIEE",
         "NormalMax": 16,
-        "PathologicMin": 17
+        "PathologicMin": 18
     },
     {
         "VariantType": "Repeat",
@@ -68,7 +68,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
-        "ReferenceRegion": "chr12:6936716-6936773",
+        "ReferenceRegion": "chr12:6936728-6936773",
         "VariantType": "Repeat",
         "Disease": "DRPLA",
         "NormalMax": 35,
@@ -925,7 +925,7 @@
         "SourceId": "NBK1427",
         "Disease": "CCHS",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr4:41745971-41746032",
+        "ReferenceRegion": "chr4:41745971-41746031",
         "VariantType": "Repeat",
         "NormalMax": 20,
         "PathologicMin": 25,
@@ -1017,7 +1017,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr6:45422751-45422801",
+        "ReferenceRegion": "chr6:45422750-45422801",
         "Disease": "CCD",
         "NormalMax": 17,
         "PathologicMin": 20
@@ -1046,7 +1046,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1438",
         "LocusStructure": "(GCA)*",
-        "ReferenceRegion": "chr6:170561906-170562017",
+        "ReferenceRegion": "chr6:170561907-170562015",
         "VariantType": "Repeat",
         "Disease": "SCA17",
         "NormalMax": 40,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1142,7 +1142,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr13:99985449-99985493",
+        "ReferenceRegion": "chr13:99985448-99985493",
         "Disease": "HPE5",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -742,7 +742,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27199925-27199966",
+        "ReferenceRegion": "chr7:27199924-27199966",
         "Disease": "HFGS",
         "NormalMax": 14,
         "PathologicMin": 22
@@ -757,7 +757,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27199826-27199861",
+        "ReferenceRegion": "chr7:27199825-27199861",
         "Disease": "HFGS",
         "NormalMax": 12,
         "PathologicMin": 18
@@ -772,7 +772,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK1423",
         "LocusStructure": "(NGC)*",
-        "ReferenceRegion": "chr7:27199679-27199732",
+        "ReferenceRegion": "chr7:27199678-27199732",
         "Disease": "HFGS",
         "NormalMax": 18,
         "PathologicMin": 24

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -180,7 +180,7 @@
         "LocusId": "C9ORF72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
-        "DisplayRU": "GGCCCC",
+        "DisplayRU": "GGGGCC",
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -7,7 +7,7 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCC)*",
+        "LocusStructure": "(CCG)*",
         "ReferenceRegion": "chrX:148500638-148500683",
         "VariantType": "Repeat",
         "Disease": "Fraxe",
@@ -97,12 +97,12 @@
         "SourceDisplay": "GeneReviews Internet 2017-06-22",
         "Source": "GeneReviews",
         "SourceId": "NBK1184",
-        "LocusStructure": "(TGC)*",
-        "ReferenceRegion": "chr6:16327633-16327723",
+        "LocusStructure": "(CTG)*",
+        "ReferenceRegion": "chr6:16327635-16327722",
         "VariantType": "Repeat",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 45
+        "PathologicMin": 40,
     },
     {
         "LocusId": "ATXN2",
@@ -112,12 +112,12 @@
         "SourceDisplay": "GeneReviews Internet 2019-02-14",
         "Source": "GeneReviews",
         "SourceId": "NBK1275",
-        "LocusStructure": "(GCT)*",
+        "LocusStructure": "(CTG)*",
         "ReferenceRegion": "chr12:111598949-111599018",
         "VariantType": "Repeat",
         "Disease": "SCA2",
         "NormalMax": 31,
-        "PathologicMin": 37
+        "PathologicMin": 33
     },
     {
         "LocusId": "ATXN3",
@@ -1204,7 +1204,6 @@
       "NormalMax": 11,
       "PathologicMin": 12
     },
-
     {
       "VariantType": ["Repeat","Repeat"],
       "LocusId": "POLG",
@@ -1215,12 +1214,11 @@
       "SourceDisplay": "Research only - contact CMMS KUH regarding findings",
       "Source": "Expert",
       "SourceId": "CMMS",    
-      "VariantId": ["POLG_I", "POLG_II"],
-      "LocusStructure": "(CTG)*TTG(CTG)*",
-      "ReferenceRegion": ["chr15:89833580-89833586",
-                          "chr15:89833589-89833628"],
-      "NormalMax": 15,
+      "VariantId": "POLG",
+      "LocusStructure": "(CTG)*",
+      "ReferenceRegion": "chr15:89833580-89833628",
+      "NormalMax": 16,
       "PathologicMin": 10000,
-      "PathologicRegion": "chr15:89833589-89833628"
+      "PathologicRegion": "chr15:89833580-89833628"
     }
 ]

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -142,19 +142,9 @@
         "SourceDisplay": "GeneReviews Internet 2019-11-07",
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
-        "LocusStructure": "(GCA)*(GCC)+",
-        "ReferenceRegion": [
-            "chr3:63912684-63912714",
-            "chr3:63912714-63912726"
-        ],
-        "VariantId": [
-            "ATXN7",
-            "ATXN7_GCC"
-        ],
-        "VariantType": [
-            "Repeat",
-            "Repeat"
-        ],
+        "LocusStructure": "(CAG)*",
+        "ReferenceRegion": "chr3:63912684-63912714",
+        "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
         "PathologicMin": 36,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1066,7 +1066,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr22:19766763-19766807",
+        "ReferenceRegion": "chr22:19766762-19766807",
         "Disease": "TOF",
         "NormalMax": 15,
         "PathologicMin": 25

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -102,7 +102,7 @@
         "VariantType": "Repeat",
         "Disease": "SCA1",
         "NormalMax": 35,
-        "PathologicMin": 40,
+        "PathologicMin": 40
     },
     {
         "LocusId": "ATXN2",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -1171,7 +1171,7 @@
         "SourceDisplay": "Tazelaar et al (2019) Neurobiol Aging 74 234.e9-234.e15",
         "Source": "PubMed",
         "SourceId": "30342764",
-        "LocusStructure": "(CGC)*",
+        "LocusStructure": "(GCG)*",
         "ReferenceRegion": "chr15:22786677-22786701",
         "Disease": "ALS - susceptibility to",
         "NormalMax": 8,
@@ -1190,7 +1190,7 @@
       "LocusStructure": "(GCA)*",
       "ReferenceRegion": "chr2:190880872-190880920",
       "Disease": "GDPAG",
-      "NormalMax": 20,
+      "NormalMax": 26,
       "PathologicMin": 90
     },
     {

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -787,7 +787,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(GCN)*",
-        "ReferenceRegion": "chr2:176093059-176093103",
+        "ReferenceRegion": "chr2:176093058-176093103",
         "Disease": "SDTY5",
         "NormalMax": 15,
         "PathologicMin": 22


### PR DESCRIPTION
### This PR adds | fixes:
- ARX_EIEE should have size 17 as intermediate/unclear pathogenicity. Known pathogenic start at 18.
- ATN1 normal max can be 35 after Udd et al in the Finnish pop
- PHOX2B, AFF2, ATN1, TBP: while not necessarily super-clear from the literature, STRipy coords look nice and clean.

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
