### PR TITLE
Add FGF14 locus

### DIFF
--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch37.json
@@ -440,6 +440,22 @@
         "PathologicMin": 10
     },
     {
+        "LocusId": "FGF14",
+        "HGNCId": 3671,
+        "InheritanceMode": "AR",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Rafehi et al 2022 AJHG S0002-9297(22)00506-7",
+        "Source": "PubMed",
+        "SourceId": "36493768",
+        "LocusStructure": "(GAA*)",
+        "ReferenceRegion": "13:102813926-102814076",
+        "VariantId": "FGF14",
+        "VariantType": "Repeat",
+        "Disease": "SCA50",
+        "NormalMax": 50,
+        "PathologicMin": 250
+    },
+    {
         "VariantType": "RareRepeat",
         "LocusId": "FMR1",
         "HGNCId": 3775,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_grch38.json
@@ -461,6 +461,22 @@
         "PathologicMin": 10
     },
     {
+        "LocusId": "FGF14",
+        "HGNCId": 3671,
+        "InheritanceMode": "AR",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Rafehi et al 2022 AJHG S0002-9297(22)00506-7",
+        "Source": "PubMed",
+        "SourceId": "36493768",
+        "LocusStructure": "(GAA*)",
+        "ReferenceRegion": "13:102161577-121161726",
+        "VariantId": "FGF14",
+        "VariantType": "Repeat",
+        "Disease": "SCA50",
+        "NormalMax": 50,
+        "PathologicMin": 250
+    },
+    {
         "LocusId": "FMR1",
         "HGNCId": 3775,
         "InheritanceMode": "XR",

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg19.json
@@ -440,6 +440,22 @@
         "PathologicMin": 10
     },
     {
+        "LocusId": "FGF14",
+        "HGNCId": 3671,
+        "InheritanceMode": "AR",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Rafehi et al 2022 AJHG S0002-9297(22)00506-7",
+        "Source": "PubMed",
+        "SourceId": "36493768",
+        "LocusStructure": "(GAA*)",
+        "ReferenceRegion": "chr13:102813926-102814076",
+        "VariantId": "FGF14",
+        "VariantType": "Repeat",
+        "Disease": "SCA50",
+        "NormalMax": 50,
+        "PathologicMin": 250
+    },
+    {
         "VariantType": "RareRepeat",
         "LocusId": "FMR1",
         "HGNCId": 3775,

--- a/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
+++ b/rare-disease/disease_loci/ExpansionHunter-v4.0.2/variant_catalog_hg38.json
@@ -461,6 +461,22 @@
         "PathologicMin": 10
     },
     {
+        "LocusId": "FGF14",
+        "HGNCId": 3671,
+        "InheritanceMode": "AR",
+        "DisplayRU": "GAA",
+        "SourceDisplay": "Rafehi et al 2022 AJHG S0002-9297(22)00506-7",
+        "Source": "PubMed",
+        "SourceId": "36493768",
+        "LocusStructure": "(GAA*)",
+        "ReferenceRegion": "chr13:102161577-121161726",
+        "VariantId": "FGF14",
+        "VariantType": "Repeat",
+        "Disease": "SCA50",
+        "NormalMax": 50,
+        "PathologicMin": 250
+    },
+    {
         "LocusId": "FMR1",
         "HGNCId": 3775,
         "InheritanceMode": "XR",


### PR DESCRIPTION
### This PR adds | fixes:
- Adds the FGF14 intronic expansion for SCA27 / SCA50 recently published (https://pubmed.ncbi.nlm.nih.gov/36493768/, direct link https://www.sciencedirect.com/science/article/pii/S0002929722005067).
- 
**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Run ExHu on a test case

### Expected outcome:
- [ ] See that FGF14 loci are reported in ExHu VCF and appear neat on eg REViewer.

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
