### PR TITLE
updating md5sums for variantcatalogs

### DIFF
--- a/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_grch37.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_grch37.json.md5
@@ -1,1 +1,1 @@
-e012949ede74938b1b12348c1ebfdb64  variant_catalog_grch37.json
+b1eadad4b49f134666b53b6e090a78b4  variant_catalog_grch37.json

--- a/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_grch38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_grch38.json.md5
@@ -1,1 +1,1 @@
-4615aab66aea9dcf3c7d3a590097502d  variant_catalog_grch38.json
+7fc0730b96ccdef9ae3075026db00bcf  variant_catalog_grch38.json

--- a/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_hg19.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_hg19.json.md5
@@ -1,1 +1,1 @@
-e73b321bcae68d1d43f328d007a26a14  variant_catalog_hg19.json
+568bcfb24d1fce24225f6af5266c9b46  variant_catalog_hg19.json

--- a/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_hg38.json.md5
+++ b/rare-disease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_hg38.json.md5
@@ -1,1 +1,1 @@
-206da2fbab9e671bfea6ed475b661be6  variant_catalog_hg38.json
+05f10a92e1b8b74064ea6277ab7acf0f  variant_catalog_hg38.json


### PR DESCRIPTION
### This PR adds | fixes:
- PR #72 did not contain updated md5 sums

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
