### PR TITLE
updates for loqusdb and clinvar

### DIFF
--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.21-.toml
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.21-.toml
@@ -1,0 +1,49 @@
+# TOML
+
+title = "Vcfanno configuration file"
+
+[functions]
+file="vcfanno_functions_-v1.0-.lua"
+
+[[annotation]]
+file="grch37_gnomad_reformated_-r2.1.1-.vcf.gz"
+fields = ["AF", "AF_popmax"]
+ops=["self", "self"]
+names=["GNOMADAF", "GNOMADAF_popmax"]
+
+[[annotation]]
+file="grch37_anon-swegen_str_nsphs_-1000samples-.vcf.gz"
+fields = ["AF", "AC_Hom", "AC_Het", "AC_Hemi"]
+ops=["self", "self", "self", "self"]
+names=["SWEGENAF", "SWEGENAAC_Hom", "SWEGENAAC_Het", "SWEGENAAC_Hemi"]
+
+[[annotation]]
+file="grch37_loqusdb_snv_indel_variants_export-20240220-.vcf.gz"
+fields = ["Frq", "Obs", "Hom"]
+ops=["self", "self", "self"]
+names=["Frq", "Obs", "Hom"]
+
+[[annotation]]
+file="grch37_genbank_haplogroup_-2015-08-01-.vcf.gz"
+fields = ["MTAF"]
+ops=["self"]
+names=["MTAF"]
+skip_normalize = true
+
+[[annotation]]
+file="grch37_gnomad_genomes_mt_-r3.1-.vcf.gz"
+fields = ["AF_hom", "AF_het", "mitotip_score", "mitotip_trna_prediction"]
+ops=["self", "self", "self", "self"]
+names=["GNOMAD_MTAF_hom", "GNOMAD_MTAF_het", "mitotip_score", "mitotip_trna_prediction"]
+
+[[annotation]]
+file="grch37_cadd_whole_genome_snvs_-v1.6-.tsv.gz"
+names=["CADD"]
+ops=["mean"]
+columns=[6]
+
+[[annotation]]
+file="grch37_spidex_public_noncommercial_-v1.1-.tsv.gz"
+names=["SPIDEX"]
+ops=["mean"]
+columns=[6]

--- a/rare-disease/annotation/grch37_vcfanno_config_-v1.21-.toml.md5
+++ b/rare-disease/annotation/grch37_vcfanno_config_-v1.21-.toml.md5
@@ -1,0 +1,1 @@
+4b3b8ee8d9f5d6284ff4276cf20f36d9  rare-disease/annotation/grch37_vcfanno_config_-v1.21-.toml

--- a/rare-disease/rank_model/rank_model_-v1.37-.ini
+++ b/rare-disease/rank_model/rank_model_-v1.37-.ini
@@ -1,0 +1,1083 @@
+[Version]
+  version = 1.37
+  name = rank_model
+
+[Categories]
+  [[allele_frequency]]
+    category_aggregation = min
+
+ [[protein_prediction]]
+   category_aggregation = sum
+
+ [[gene_intolerance_prediction]]
+   category_aggregation = max
+
+ [[inheritance_models]]
+   category_aggregation = min
+
+ [[consequence]]
+   category_aggregation = max
+
+ [[conservation]]
+   category_aggregation = sum
+
+ [[variant_call_quality_filter]]
+   category_aggregation = sum
+
+ [[deleteriousness]]
+   category_aggregation = max
+
+ [[clinical_significance]]
+   category_aggregation = sum
+
+ [[splicing]]
+   category_aggregation = max
+
+[maxentscan_naitive_alt]
+  category = splicing
+  csq_key = MaxEntScan_alt
+  data_type = float
+  description = MaxEntScan alternative score for naitive
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 3
+    lower = 0
+    upper = 6.2
+
+  [[medium]]
+    score = 2
+    lower = 6.2
+    upper = 8.5
+
+  [[high]]
+    score = 0
+    lower = 8.5
+    upper = 100
+
+[maxentscan_naitive_diff]
+  category = splicing
+  csq_key =MaxEntScan_diff
+  data_type = float
+  description = MaxEntScan difference score for naitive
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = 0
+    upper = 1.15
+
+  [[high]]
+    score = 2
+    lower = 1.15
+    upper = 100
+
+[maxentscan_mes_swa_acceptor_alt]
+  category = splicing
+  csq_key = MES-SWA_acceptor_alt
+  data_type = float
+  description = MaxEntScan MES-SWA acceptor alternative score for de novo
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = 0
+    upper = 6.2
+
+  [[medium]]
+    score = 1
+    lower = 6.2
+    upper = 8.5
+
+  [[high]]
+    score = 3
+    lower = 8.5
+    upper = 100
+
+[maxentscan_mes_swa_acceptor_diff]
+  category = splicing
+  csq_key = MES-SWA_acceptor_diff
+  data_type = float
+  description = MaxEntScan MES_SWA acceptor difference score for de novo
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = -100
+    upper = 0
+
+[maxentscan_mes_swa_donor_alt]
+  category = splicing
+  csq_key = MES-SWA_donor_alt
+  data_type = float
+  description = MaxEntScan MES-SWA donor score for de novo
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = 0
+    upper = 6.2
+
+  [[medium]]
+    score = 1
+    lower = 6.2
+    upper = 8.5
+
+  [[high]]
+    score = 3
+    lower = 8.5
+    upper = 100
+
+[maxentscan_mes_swa_donor_diff]
+  category = splicing
+  csq_key = MES-SWA_donor_diff
+  data_type = float
+  description = MaxEntScan MES-SWA donor difference score for de novo
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = -100
+    upper = 0
+
+[spidex]
+  category = splicing
+  data_type = float
+  description = Spidex z score
+  field = INFO
+  info_key = SPIDEX
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = -1
+    upper = 1
+
+  [[medium_pos]]
+    score = 3
+    lower = 1
+    upper = 2
+
+  [[medium_neg]]
+    score = 3
+    lower = -2
+    upper = -1
+
+  [[high_pos]]
+    score = 5
+    lower = 2
+    upper = 100
+
+  [[high_neg]]
+    score = 5
+    lower = -100
+    upper = -2
+
+[spliceai_ds_ag]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_AG
+  data_type = float
+  description = SpliceAI delta score acceptor gain
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_al]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_AL
+  data_type = float
+  description = SpliceAI delta score acceptor loss
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_dg]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_DG
+  data_type = float
+  description = SpliceAI delta score donor gain
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_dl]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_DL
+  data_type = float
+  description = SpliceAI delta score donor loss
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[model_score]
+  category = variant_call_quality_filter
+  data_type = integer
+  description = Inheritance model score
+  field = INFO
+  info_key = ModelScore
+  record_rule = min
+  separators = ',',':',
+
+  [[not_reported]]
+    score = 0
+
+  [[low_qual]]
+    score = -5
+    lower = 0
+    upper = 10
+
+  [[medium_qual]]
+    score = -2
+    lower = 10
+    upper = 20
+
+  [[high_qual]]
+    score = 0
+    lower = 20
+    upper = 300
+
+[swegen]
+  category = allele_frequency
+  data_type = float
+  description = Swegen genomes frequency
+  field = INFO
+  info_key = SWEGENAF
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 4
+
+  [[common]]
+    score = -12
+    lower = 0.02
+    upper = 1.1
+
+  [[intermediate]]
+    score = 1
+    lower = 0.005
+    upper = 0.02
+
+ [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+ [[very_rare]]
+    score = 3
+    lower = 0
+    upper = 0.0005
+
+[gnomad]
+  category = allele_frequency
+  data_type = float
+  description = GnomAD frequency
+  field = INFO
+  info_key = GNOMADAF_popmax
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 4
+
+  [[common]]
+    score = -12
+    lower = 0.02
+    upper = 1.1
+
+  [[intermediate]]
+    score = 1
+    lower = 0.005
+    upper = 0.02
+
+  [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+  [[very_rare]]
+    score = 3
+    lower = 0
+    upper = 0.0005
+
+[mtaf]
+  category = allele_frequency
+  data_type = float
+  description = genbank MT frequency
+  field = INFO
+  info_key = MTAF
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 4
+
+  [[common]]
+    score = -12
+    lower = 0.02
+    upper = 1.1
+
+  [[intermediate]]
+    score = 1
+    lower = 0.005
+    upper = 0.02
+
+  [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+  [[very_rare]]
+    score = 3
+    lower = 0
+    upper = 0.0005
+
+[loqusdb]
+  category = allele_frequency
+  data_type = float
+  description = LoqusDb observation frequency for cases=11889
+  field = INFO
+  info_key = Frq
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 4
+
+  [[common]]
+    score = -12
+    lower = 0.02
+    upper = 1.1
+
+  [[intermediate]]
+    score = 1
+    lower = 0.005
+    upper = 0.02
+
+  [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+  [[very_rare]]
+    score = 3
+    lower = 0
+    upper = 0.0005
+
+[polyphen]
+  category = protein_prediction
+  csq_key = PolyPhen
+  data_type = string
+  description = Polyphen prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[probably_damaging]]
+    score = 1
+    priority = 3
+    string = 'probably_damaging'
+
+  [[possibly_damaging]]
+    score = 1
+    priority = 2
+    string = 'possibly_damaging'
+
+  [[bening]]
+    score = 0
+    priority = 1
+    string = 'benign'
+
+[revel]
+  category = protein_prediction
+  csq_key = REVEL_score
+  data_type = float
+  description = Revel score prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[tolerated]]
+    score = 0
+    lower = 0
+    upper = 0.5
+
+  [[probably_damaging]]
+    score = 2
+    lower = 0.5
+    upper = 0.75
+
+  [[damaging]]
+    score = 5
+    lower = 0.75
+    upper = 1
+
+[sift]
+  category = protein_prediction
+  csq_key = SIFT
+  data_type = string
+  description = Sift prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[deleterious]]
+    score = 1
+    priority = 2
+    string = 'deleterious'
+
+  [[tolerated]]
+    score = 0
+    priority = 1
+    string = 'tolerated'
+
+[gene_intolerance_score]
+  category = gene_intolerance_prediction
+  csq_key = LoFtool
+  data_type = float
+  description = LofTool gene intolerance prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[high_intolerance]]
+    score = 4
+    lower = 0
+    upper = 0.01
+
+  [[medium_intolerance]]
+    score = 2
+    lower = 0.01
+    upper = 0.1
+
+  [[low_intolerance]]
+    score = 0
+    lower = 0.1
+    upper = 1
+
+[genetic_models]
+  category = inheritance_models
+  data_type = string
+  description = Inheritance models followed for the variant
+  field = INFO
+  info_key = GeneticModels
+  record_rule = max
+  separators = ',', ':', '|',
+
+ [[ad]]
+   priority = 1
+   score = 1
+   string = 'AD'
+
+ [[ad_dn]]
+   score = 1
+   priority = 1
+   string = 'AD_dn'
+
+ [[ar]]
+   score = 1
+   priority = 1
+   string = 'AR_hom'
+
+ [[ar_dn]]
+   score = 1
+   priority = 1
+   string = 'AR_hom_dn'
+
+ [[ar_comp]]
+   score = 1
+   priority = 1
+   string = 'AR_comp'
+
+ [[ar_comp_dn]]
+   score = 1
+   priority = 1
+   string = 'AR_comp_dn'
+
+ [[xr]]
+   score = 1
+   priority = 1
+   string = 'XR'
+
+ [[xr_dn]]
+   score = 1
+   priority = 1
+   string = 'XR_dn'
+
+ [[xd]]
+   score = 1
+   priority = 1
+   string = 'XD'
+
+ [[xd_dn]]
+   score = 1
+   priority = 1
+   string = 'XD_dn'
+
+ [[not_reported]]
+   score = -12
+
+[most_severe_consequence]
+  category = consequence
+  data_type = string
+  description = Most severe consequence for this variant (vep107)
+  field = INFO
+  info_key = most_severe_consequence
+  record_rule = max
+  separators = ',', ':', '|',
+
+  [[transcript_ablation]]
+    score = 10
+    priority = 6
+    string = 'transcript_ablation'
+
+  [[splice_acceptor_variant]]
+    score = 8
+    priority = 5
+    string = 'splice_acceptor_variant'
+
+  [[splice_donor_variant]]
+    score = 8
+    priority = 5
+    string = 'splice_donor_variant'
+
+  [[stop_gained]]
+    score = 8
+    priority = 5
+    string = 'stop_gained'
+
+  [[frameshift_variant]]
+    score = 8
+    priority = 5
+    string = 'frameshift_variant'
+
+  [[stop_lost]]
+    score = 8
+    priority = 5
+    string = 'stop_lost'
+
+  [[start_lost]]
+    score = 8
+    priority = 5
+    string = 'start_lost'
+
+  [[transcript_amplification]]
+    score = 5
+    priority = 4
+    string = 'transcript_amplification'
+
+  [[inframe_insertion]]
+    score = 5
+    priority = 4
+    string = 'inframe_insertion'
+
+  [[inframe_deletion]]
+    score = 5
+    priority = 4
+    string = 'inframe_deletion'
+
+  [[missense_variant]]
+    score = 5
+    priority = 4
+    string = 'missense_variant'
+
+  [[protein_altering_variant]]
+    score = 5
+    priority = 4
+    string = 'protein_altering_variant'
+
+  [[splice_region_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_region_variant'
+
+  [[splice_donor_5th_base_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_5th_base_variant'
+
+  [[splice_donor_region_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_donor_region_variant'
+
+  [[splice_polypyrimidine_tract_variant]]
+    score = 5
+    priority = 4
+    string = 'splice_polypyrimidine_tract_variant'
+
+  [[incomplete_terminal_codon_variant]]
+    score = 5
+    priority = 4
+    string = 'incomplete_terminal_codon_variant'
+
+  [[non_coding_transcript_exon_variant]]
+    score = 3
+    priority = 2
+    string = 'non_coding_transcript_exon_variant'
+
+  [[synonymous_variant]]
+    score = 2
+    priority = 2
+    string = 'synonymous_variant'
+
+  [[start_retained_variant]]
+    score = 1
+    priority = 2
+    string = 'start_retained_variant'
+
+  [[stop_retained_variant]]
+    score = 1
+    priority = 2
+    string = 'stop_retained_variant'
+
+  [[coding_sequence_variant]]
+    score = 1
+    priority = 2
+    string = 'coding_sequence_variant'
+
+  [[mature_miRNA_variant]]
+    score = 1
+    priority = 2
+    string = 'mature_miRNA_variant'
+
+  [[5_prime_UTR_variant]]
+    score = 1
+    priority = 2
+    string = '5_prime_UTR_variant'
+
+  [[3_prime_UTR_variant]]
+    score = 1
+    priority = 2
+    string = '3_prime_UTR_variant'
+
+  [[intron_variant]]
+    score = 1
+    priority = 2
+    string = 'intron_variant'
+
+  [[NMD_transcript_variant]]
+    score = 1
+    priority = 2
+    string = 'NMD_transcript_variant'
+
+  [[non_coding_transcript_variant]]
+    score = 1
+    priority = 2
+    string = 'non_coding_transcript_variant'
+
+  [[upstream_gene_variant]]
+    score = 1
+    priority = 2
+    string = 'upstream_gene_variant'
+
+  [[downstream_gene_variant]]
+    score = 1
+    priority = 2
+    string = 'downstream_gene_variant'
+
+  [[TFBS_ablation]]
+    score = 1
+    priority = 2
+    string = 'TFBS_ablation'
+
+  [[TFBS_amplification]]
+    score = 1
+    priority = 2
+    string = 'TFBS_amplification'
+
+  [[TF_binding_site_variant]]
+    score = 1
+    priority = 2
+    string = 'TF_binding_site_variant'
+
+  [[regulatory_region_ablation]]
+    score = 1
+    priority = 2
+    string = 'regulatory_region_ablation'
+
+  [[regulatory_region_amplification]]
+    score = 1
+    priority = 2
+    string = 'regulatory_region_amplification'
+
+  [[feature_elongation]]
+    score = 1
+    priority = 2
+    string = 'feature_elongation'
+
+  [[regulatory_region_variant]]
+    score = 1
+    priority = 2
+    string = 'regulatory_region_variant'
+
+  [[feature_truncation]]
+    score = 1
+    priority = 2
+    string = 'feature_truncation'
+
+  [[intergenic_variant]]
+    score = 0
+    priority = 0
+    string = 'intergenic_variant'
+
+  [[not_reported]]
+    score = 0
+
+[filter]
+  category = variant_call_quality_filter
+  data_type = string
+  description = The filters for the variant
+  field = FILTER
+  record_rule = min
+  separators = ';',
+
+  [[not_reported]]
+    score = 0
+
+  [[pass]]
+    score = 3
+    priority = 1
+    string = 'PASS'
+
+  [[dot]]
+    score = 3
+    priority = 2
+    string = '.'
+
+[dbnsfp_gerp++_rs]
+  category = conservation
+  csq_key = GERP++_RS
+  data_type = float
+  description = Gerp conservation score
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[conserved]]
+    score = 1
+    lower = 2
+    upper = 10
+
+  [[not_conserved]]
+    score = 0
+    lower = 0
+    upper = 2
+
+[dbnsfp_phastcons100way_vertebrate]
+  category = conservation
+  csq_key = phastCons100way_vertebrate
+  data_type = float
+  description = phastCons conservation score
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[conserved]]
+    score = 1
+    lower = 0.8
+    upper = 100
+
+  [[not_conserved]]
+    score = 0
+    lower = 0
+    upper = 0.8
+
+[dbnsfp_phylop100way_vertebrate]
+  category = conservation
+  csq_key = phyloP100way_vertebrate
+  data_type = float
+  description = Phylop conservation score
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[conserved]]
+    score = 1
+    lower = 2.5
+    upper = 100
+
+  [[not_conserved]]
+    score = 0
+    lower = 0
+    upper = 2.5
+
+[cadd]
+  category = deleteriousness
+  data_type = float
+  description = CADD deleterious score
+  field = INFO
+  info_key = CADD
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = 0
+    upper = 10
+
+  [[medium]]
+    score = 2
+    lower = 10
+    upper = 20
+
+  [[high]]
+    score = 3
+    lower = 20
+    upper = 30
+
+  [[higher]]
+    score = 4
+    lower = 30
+    upper = 40
+
+  [[highest]]
+    score = 5
+    lower = 40
+    upper = 100
+
+[clnsig]
+  category = clinical_significance
+  csq_key = CLINVAR_CLNSIG
+  data_type = string
+  description = Clinical significance
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = '/',",",
+
+  [[not_provided]]
+    score = 0
+    priority = 0
+    string = 'not_provided'
+
+  [[drug_response]]
+    score = 0
+    priority = 0
+    string = '_drug_response'
+
+  [[other]]
+    score = 0
+    priority = 0
+    string = '_other'
+
+  [[Uncertain_significance]]
+    score = 0
+    priority = 1
+    string = 'Uncertain_significance'
+    value = 0
+
+  [[Likely_benign]]
+    score = 0
+    priority = 1
+    string = 'Likely_benign'
+
+  [[Benign]]
+    score = -1
+    priority = 2
+    string = 'Benign'
+
+  [[Likely_pathogenic]]
+    score = 5
+    priority = 2
+    string = 'Likely_pathogenic'
+
+  [[Pathogenic]]
+    score = 5
+    priority = 3
+    string = 'Pathogenic'
+
+[clnrevstat]
+  category = clinical_significance
+  csq_key = CLINVAR_CLNREVSTAT
+  data_type = string
+  description = Clinical_review_status
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[no_assertion]]
+    score = 0
+    priority = 0
+    string = 'no_assertion_criteria_provided'
+
+  [[criteria]]
+    score = 1
+    priority = 0
+    string = 'criteria_provided'
+
+  [[single]]
+    score = 1
+    priority = 1
+    string = '_single_submitter'
+
+  [[conf]]
+    score = 1
+    priority = 1
+    string = '_no_conflicts'
+
+  [[mult]]
+    score = 2
+    priority = 2
+    string = '_multiple_submitters'
+
+  [[exp]]
+    score = 3
+    priority = 3
+    string = 'reviewed_by_expert_panel'
+
+  [[guideline]]
+    score = 4
+    priority = 4
+    string = 'practice_guideline'

--- a/rare-disease/rank_model/rank_model_-v1.37-.ini.md5
+++ b/rare-disease/rank_model/rank_model_-v1.37-.ini.md5
@@ -1,0 +1,1 @@
+76514b6d08e42950ac604fce77b8a085  rare-disease/rank_model/rank_model_-v1.37-.ini


### PR DESCRIPTION
### This PR adds | fixes:
- Updating loqusdb and clinvar triggers new versions of the vcfanno config and the rankmodell



### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
