### PR TITLE
Fix Nallo SNV rank model

### DIFF
--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -186,7 +186,7 @@
   
   [[missing]]
     score = 4
-    lower = -1
+    lower = -2
     upper = -1
 
   [[common]]
@@ -678,7 +678,7 @@
   
   [[missing]]
     score = 4
-    lower = -1
+    lower = -2
     upper = -1
 
   [[common]]

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -186,8 +186,8 @@
   
   [[missing]]
     score = 4
-    lower = -2
-    upper = -1
+    lower = -1
+    upper = 0
 
   [[common]]
     score = -12
@@ -678,8 +678,8 @@
   
   [[missing]]
     score = 4
-    lower = -2
-    upper = -1
+    lower = -1
+    upper = 0
 
   [[common]]
     score = -12


### PR DESCRIPTION
## Description

Genmod gives error with the current version, this seems to fix it.

```
  Traceback (most recent call last):
    File "/usr/local/bin/genmod", line 10, in <module>
      sys.exit(cli())
    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
      return self.main(*args, **kwargs)
    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1078, in main
      rv = self.invoke(ctx)
    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
      return _process_result(sub_ctx.command.invoke(sub_ctx))
    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
      return ctx.invoke(self.callback, **ctx.params)
    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 783, in invoke
      return __callback(*args, **kwargs)
    File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 33, in new_func
      return f(get_current_context(), *args, **kwargs)
    File "/usr/local/lib/python3.8/site-packages/genmod/commands/score_variants.py", line 92, in score
      config_parser = ConfigParser(score_config)
    File "/usr/local/lib/python3.8/site-packages/genmod/score_variants/config_parser.py", line 139, in __init__
      self.score_functions[plugin] = self.get_score_function(plugin_info)
    File "/usr/local/lib/python3.8/site-packages/genmod/score_variants/config_parser.py", line 201, in get_score_function
      score_function.add_interval(
    File "/usr/local/lib/python3.8/site-packages/genmod/score_variants/score_function.py", line 68, in add_interval
      self._interval_tree[lower:upper] = score
    File "/usr/local/lib/python3.8/site-packages/intervaltree/intervaltree.py", line 1060, in __setitem__
      self.addi(index.start, index.stop, value)
    File "/usr/local/lib/python3.8/site-packages/intervaltree/intervaltree.py", line 343, in addi
      return self.add(Interval(begin, end, data))
    File "/usr/local/lib/python3.8/site-packages/intervaltree/intervaltree.py", line 324, in add
      raise ValueError(
  ValueError: IntervalTree: Null Interval objects not allowed in IntervalTree: Interval(-1.0, -1.0, 4.0)
```

### Added

-

### Changed

-

### Fixed

- Fix Nallo SNV rank model not working with genmod 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
