### PR TITLE
Annotate nallo rank models

### DIFF
--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -171,7 +171,7 @@
   description = Clinical significance
   field = INFO
   info_key = CSQ
-  record_rule = max # Why max? All of these should be mutually exclusive?
+  record_rule = max # This is just here because genmod requires it, but it doesn't really matter becuase the strings are mutually exclusive.
   separators = '/',",",
 
   [[not_provided]]

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -40,7 +40,8 @@
     category_aggregation = sum
 
   # This is SpliceAI, which has multiple scores for different types of splicing effects.
-  # We want to get the maximum score across all of them (why not sum?).
+  # We want to get the maximum score across all of them, since "[the] Delta score of a variant, defined as the maximum of (DS_AG, DS_AL, DS_DG, DS_DL),
+  # ranges from 0 to 1 and can be interpreted as the probability of the variant being splice-altering." (https://github.com/illumina/spliceAI).
   [[splicing]]
     category_aggregation = max
 

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -3,174 +3,126 @@
   name = rank_model
 
 [Categories]
+  # We want to penalize common variants, the more common the lower score.
+  # Since we have multiple sources, we want to take the lowest score (most common) across all sources.
   [[allele_frequency]]
     category_aggregation = min
 
- [[protein_prediction]]
-   category_aggregation = sum
+  # For clinical significance (ClinVar), we include both the clinical significance and the review status.
+  # We want to sum the scores for both (why?), but we want to take the maximum score for each category.
+  [[clinical_significance]]
+    category_aggregation = sum
 
- [[gene_intolerance_prediction]]
-   category_aggregation = max
+  # Consequence (most_severe_consequence) only has one source, and so doesn't really matter how we aggregate.
+  [[consequence]]
+    category_aggregation = max
 
- [[inheritance_models]]
-   category_aggregation = min
+  # For conservation (GERP++_RS, phastCons, phylop) we have multiple sources, each giving between 0 and 1.
+  # We want to sum the scores for all sources (why?).
+  [[conservation]]
+    category_aggregation = sum
 
- [[consequence]]
-   category_aggregation = max
+  # Deleteriousness is just CADD, so it doesn't really matter how we aggregate.
+  [[deleteriousness]]
+    category_aggregation = max
 
- [[conservation]]
-   category_aggregation = sum
+  # Gene intolerance prediction is just LofTool, so it doesn't really matter how we aggregate.
+  [[gene_intolerance_prediction]]
+    category_aggregation = max
 
- [[variant_call_quality_filter]]
-   category_aggregation = sum
+  # Inheritance models is just one category from `genmod models`, could we just set max here for consistency?
+  [[inheritance_models]]
+    category_aggregation = min
 
- [[deleteriousness]]
-   category_aggregation = max
+  # This is just REVEL, so it doesn't really matter how we aggregate.
+  [[protein_prediction]]
+    category_aggregation = sum
 
- [[clinical_significance]]
-   category_aggregation = sum
+  # This is SpliceAI, which has multiple scores for different types of splicing effects.
+  # We want to get the maximum score across all of them (why not sum?).
+  [[splicing]]
+    category_aggregation = max
 
- [[splicing]]
-   category_aggregation = max
+  # Here we have the model filter (from genmod) and the filter field (from the VCF), which both give an indication of the quality of the variant call.
+  # The filter field is not really in use, and just gives a +3 to all variants.
+  [[variant_call_quality_filter]]
+    category_aggregation = sum
 
-[spliceai_ds_ag]
-  category = splicing
-  csq_key = SpliceAI_pred_DS_AG
+#
+# Allele frequency
+#
+[gnomad]
+  category = allele_frequency
   data_type = float
-  description = SpliceAI delta score acceptor gain
+  description = GnomAD frequency
   field = INFO
-  info_key = CSQ
+  info_key = gnomad_popmax_af
   record_rule = max
   separators = ',',
 
   [[not_reported]]
-    score = 0
+    score = 4
 
-  [[low]]
+  [[missing]]
+    score = 4
+    lower = -1
+    upper = 0
+
+  [[common]]
+    score = -12
+    lower = 0.02 # When a score is exactly 0.02, it gets the score of whichever category has it has `lower` (?) # TODO: Add this to a general README.
+    upper = 1.1
+
+  [[intermediate]]
     score = 1
-    lower = 0
-    upper = 0.2
+    lower = 0.005
+    upper = 0.02
 
-  [[medium]]
+  [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+  [[very_rare]]
     score = 3
-    lower = 0.2
-    upper = 0.5
+    lower = 0
+    upper = 0.0005
 
-  [[high]]
-    score = 5
-    lower = 0.5
-    upper = 100
-
-[spliceai_ds_al]
-  category = splicing
-  csq_key = SpliceAI_pred_DS_AL
+[loqusdb]
+  category = allele_frequency
   data_type = float
-  description = SpliceAI delta score acceptor loss
   field = INFO
-  info_key = CSQ
+  info_key = Frq
   record_rule = max
   separators = ',',
 
   [[not_reported]]
-    score = 0
+    score = 4
 
-  [[low]]
+  [[missing]]
+    score = 4
+    lower = -1
+    upper = 0
+
+  [[common]]
+    score = -12
+    lower = 0.02
+    upper = 1.1
+
+  [[intermediate]]
     score = 1
-    lower = 0
-    upper = 0.2
+    lower = 0.005
+    upper = 0.02
 
-  [[medium]]
+  [[rare]]
+    score = 2
+    lower = 0.0005
+    upper = 0.005
+
+  [[very_rare]]
     score = 3
-    lower = 0.2
-    upper = 0.5
-
-  [[high]]
-    score = 5
-    lower = 0.5
-    upper = 100
-
-[spliceai_ds_dg]
-  category = splicing
-  csq_key = SpliceAI_pred_DS_DG
-  data_type = float
-  description = SpliceAI delta score donor gain
-  field = INFO
-  info_key = CSQ
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 0
-
-  [[low]]
-    score = 1
     lower = 0
-    upper = 0.2
-
-  [[medium]]
-    score = 3
-    lower = 0.2
-    upper = 0.5
-
-  [[high]]
-    score = 5
-    lower = 0.5
-    upper = 100
-
-[spliceai_ds_dl]
-  category = splicing
-  csq_key = SpliceAI_pred_DS_DL
-  data_type = float
-  description = SpliceAI delta score donor loss
-  field = INFO
-  info_key = CSQ
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 0
-
-  [[low]]
-    score = 1
-    lower = 0
-    upper = 0.2
-
-  [[medium]]
-    score = 3
-    lower = 0.2
-    upper = 0.5
-
-  [[high]]
-    score = 5
-    lower = 0.5
-    upper = 100
-
-[model_score]
-  category = variant_call_quality_filter
-  data_type = integer
-  description = Inheritance model score
-  field = INFO
-  info_key = ModelScore
-  record_rule = min
-  separators = ',',':',
-
-  [[not_reported]]
-    score = 0
-
-  [[low_qual]]
-    score = -5
-    lower = 0
-    upper = 10
-
-  [[medium_qual]]
-    score = -2
-    lower = 10
-    upper = 20
-
-  [[high_qual]]
-    score = 0
-    lower = 20
-    upper = 300
+    upper = 0.0005
 
 [colorsdb]
   category = allele_frequency
@@ -209,96 +161,115 @@
     lower = 0
     upper = 0.0005
 
-[gene_intolerance_score]
-  category = gene_intolerance_prediction
-  csq_key = LoFtool
-  data_type = float
-  description = LofTool gene intolerance prediction
+#
+# Clinical significance
+#
+[clnsig]
+  category = clinical_significance
+  csq_key = CLINVAR_CLNSIG
+  data_type = string
+  description = Clinical significance
+  field = INFO
+  info_key = CSQ
+  record_rule = max # Why max? All of these should be mutually exclusive?
+  separators = '/',",",
+
+  [[not_provided]]
+    score = 0
+    priority = 0
+    string = 'not_provided'
+
+  [[drug_response]]
+    score = 0
+    priority = 0
+    string = '_drug_response'
+
+  [[other]]
+    score = 0
+    priority = 0
+    string = '_other'
+
+  [[Uncertain_significance]]
+    score = 0
+    priority = 1
+    string = 'Uncertain_significance'
+    value = 0 # why does this have a value?
+
+  [[Likely_benign]]
+    score = 0
+    priority = 1
+    string = 'Likely_benign'
+
+  # `Benign` can have the same priority as `Likely_pathogenic` since they are mutually exclusive.
+  # So there's no need to differentiate between them in terms of priority.
+  [[Benign]]
+    score = -1
+    priority = 2
+    string = 'Benign'
+
+  [[Likely_pathogenic]]
+    score = 5
+    priority = 2
+    string = 'Likely_pathogenic'
+
+  [[Pathogenic]]
+    score = 5
+    priority = 3
+    string = 'Pathogenic'
+
+[clnrevstat]
+  category = clinical_significance
+  csq_key = CLINVAR_CLNREVSTAT
+  data_type = string
+  description = Clinical_review_status
   field = INFO
   info_key = CSQ
   record_rule = max
-  separators = None
+  separators = ',',
 
   [[not_reported]]
     score = 0
 
-  [[high_intolerance]]
-    score = 4
-    lower = 0
-    upper = 0.01
-
-  [[medium_intolerance]]
-    score = 2
-    lower = 0.01
-    upper = 0.1
-
-  [[low_intolerance]]
+  # `no_assertion` and `criteria` can have the same priority since they are mutually exclusive.
+  # So there's no need to differentiate between them in terms of priority.
+  [[no_assertion]]
     score = 0
-    lower = 0.1
-    upper = 1
+    priority = 0
+    string = 'no_assertion_criteria_provided'
 
-[genetic_models]
-  category = inheritance_models
-  data_type = string
-  description = Inheritance models followed for the variant
-  field = INFO
-  info_key = GeneticModels
-  record_rule = max
-  separators = ',', ':', '|',
+  [[criteria]]
+    score = 1
+    priority = 0
+    string = 'criteria_provided'
 
- [[ad]]
-   priority = 1
-   score = 1
-   string = 'AD'
+  [[single]]
+    score = 1
+    priority = 1
+    string = '_single_submitter'
 
- [[ad_dn]]
-   score = 1
-   priority = 1
-   string = 'AD_dn'
+  [[conf]]
+    score = 1
+    priority = 1
+    string = '_no_conflicts'
 
- [[ar]]
-   score = 1
-   priority = 1
-   string = 'AR_hom'
+  [[mult]]
+    score = 2
+    priority = 2
+    string = '_multiple_submitters'
 
- [[ar_dn]]
-   score = 1
-   priority = 1
-   string = 'AR_hom_dn'
+  [[exp]]
+    score = 3
+    priority = 3
+    string = 'reviewed_by_expert_panel'
 
- [[ar_comp]]
-   score = 1
-   priority = 1
-   string = 'AR_comp'
+  [[guideline]]
+    score = 4
+    priority = 4
+    string = 'practice_guideline'
 
- [[ar_comp_dn]]
-   score = 1
-   priority = 1
-   string = 'AR_comp_dn'
-
- [[xr]]
-   score = 1
-   priority = 1
-   string = 'XR'
-
- [[xr_dn]]
-   score = 1
-   priority = 1
-   string = 'XR_dn'
-
- [[xd]]
-   score = 1
-   priority = 1
-   string = 'XD'
-
- [[xd_dn]]
-   score = 1
-   priority = 1
-   string = 'XD_dn'
-
- [[not_reported]]
-   score = -12
-
+#
+# Consequence
+#
 [most_severe_consequence]
   category = consequence
   data_type = string
@@ -313,6 +284,9 @@
     priority = 6
     string = 'transcript_ablation'
 
+  # `splice_acceptor_variant`, `splice_donor_variant`, `stop_gained` etc. are not mutually exclusive.
+  # For the ranking, this doesn't matter as long as they have the same score.
+  # We just need to make sure that each score has it's own priority.
   [[splice_acceptor_variant]]
     score = 8
     priority = 5
@@ -393,6 +367,9 @@
     priority = 4
     string = 'incomplete_terminal_codon_variant'
 
+  # `non_coding_transcript_exon_variant`, `synonymous_variant` etc. have the same priority, but different scores.
+  # This means that if a variant has both `non_coding_transcript_exon_variant` and `synonymous_variant` it will get the score of `synonymous_variant`,
+  # even though `non_coding_transcript_exon_variant` has a higher score.
   [[non_coding_transcript_exon_variant]]
     score = 3
     priority = 2
@@ -506,265 +483,9 @@
   [[not_reported]]
     score = 0
 
-[filter]
-  category = variant_call_quality_filter
-  data_type = string
-  description = The filters for the variant
-  field = FILTER
-  record_rule = min
-  separators = ';',
-
-  [[not_reported]]
-    score = 0
-
-  [[pass]]
-    score = 3
-    priority = 1
-    string = 'PASS'
-
-  [[dot]]
-    score = 3
-    priority = 2
-    string = '.'
-
-[cadd]
-  category = deleteriousness
-  data_type = float
-  description = CADD deleterious score
-  field = INFO
-  info_key = CADD
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 0
-
-  [[low]]
-    score = 0
-    lower = 0
-    upper = 10
-
-  [[medium]]
-    score = 2
-    lower = 10
-    upper = 20
-
-  [[high]]
-    score = 3
-    lower = 20
-    upper = 30
-
-  [[higher]]
-    score = 4
-    lower = 30
-    upper = 40
-
-  [[highest]]
-    score = 5
-    lower = 40
-    upper = 100
-
-
-[clnsig]
-  category = clinical_significance
-  csq_key = CLINVAR_CLNSIG
-  data_type = string
-  description = Clinical significance
-  field = INFO
-  info_key = CSQ
-  record_rule = max
-  separators = '/',",",
-
-  [[not_provided]]
-    score = 0
-    priority = 0
-    string = 'not_provided'
-
-  [[drug_response]]
-    score = 0
-    priority = 0
-    string = '_drug_response'
-
-  [[other]]
-    score = 0
-    priority = 0
-    string = '_other'
-
-  [[Uncertain_significance]]
-    score = 0
-    priority = 1
-    string = 'Uncertain_significance'
-    value = 0
-
-  [[Likely_benign]]
-    score = 0
-    priority = 1
-    string = 'Likely_benign'
-
-  [[Benign]]
-    score = -1
-    priority = 2
-    string = 'Benign'
-
-  [[Likely_pathogenic]]
-    score = 5
-    priority = 2
-    string = 'Likely_pathogenic'
-
-  [[Pathogenic]]
-    score = 5
-    priority = 3
-    string = 'Pathogenic'
-
-[clnrevstat]
-  category = clinical_significance
-  csq_key = CLINVAR_CLNREVSTAT
-  data_type = string
-  description = Clinical_review_status
-  field = INFO
-  info_key = CSQ
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 0
-
-  [[no_assertion]]
-    score = 0
-    priority = 0
-    string = 'no_assertion_criteria_provided'
-
-  [[criteria]]
-    score = 1
-    priority = 0
-    string = 'criteria_provided'
-
-  [[single]]
-    score = 1
-    priority = 1
-    string = '_single_submitter'
-
-  [[conf]]
-    score = 1
-    priority = 1
-    string = '_no_conflicts'
-
-  [[mult]]
-    score = 2
-    priority = 2
-    string = '_multiple_submitters'
-
-  [[exp]]
-    score = 3
-    priority = 3
-    string = 'reviewed_by_expert_panel'
-
-  [[guideline]]
-    score = 4
-    priority = 4
-    string = 'practice_guideline'
-
-[gnomad]
-  category = allele_frequency
-  data_type = float
-  description = GnomAD frequency
-  field = INFO
-  info_key = gnomad_popmax_af
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 4
-
-  [[missing]]
-    score = 4
-    lower = -1
-    upper = 0
-
-  [[common]]
-    score = -12
-    lower = 0.02
-    upper = 1.1
-
-  [[intermediate]]
-    score = 1
-    lower = 0.005
-    upper = 0.02
-
-  [[rare]]
-    score = 2
-    lower = 0.0005
-    upper = 0.005
-
-  [[very_rare]]
-    score = 3
-    lower = 0
-    upper = 0.0005
-
-[loqusdb]
-  category = allele_frequency
-  data_type = float
-  field = INFO
-  info_key = Frq
-  record_rule = max
-  separators = ',',
-
-  [[not_reported]]
-    score = 4
-
-  [[missing]]
-    score = 4
-    lower = -1
-    upper = 0
-
-  [[common]]
-    score = -12
-    lower = 0.02
-    upper = 1.1
-
-  [[intermediate]]
-    score = 1
-    lower = 0.005
-    upper = 0.02
-
-  [[rare]]
-    score = 2
-    lower = 0.0005
-    upper = 0.005
-
-  [[very_rare]]
-    score = 3
-    lower = 0
-    upper = 0.0005
-
-[revel]
-  category = protein_prediction
-  csq_key = REVEL_score
-  data_type = float
-  description = Revel score prediction
-  field = INFO
-  info_key = CSQ
-  record_rule = max
-  separators = None
-
-  [[not_reported]]
-    score = 0
-
-  [[tolerated]]
-    score = 0
-    lower = 0
-    upper = 0.5
-
-  [[probably_damaging]]
-    score = 2
-    lower = 0.5
-    upper = 0.75
-
-  [[damaging]]
-    score = 5
-    lower = 0.75
-    upper = 1
-
+#
+# Conservation
+#
 [dbnsfp_gerp++_rs]
   category = conservation
   csq_key = GERP++_RS
@@ -833,3 +554,342 @@
     score = 0
     lower = 0
     upper = 2.5
+
+#
+# Deleteriousness
+#
+[cadd]
+  category = deleteriousness
+  data_type = float
+  description = CADD deleterious score
+  field = INFO
+  info_key = CADD
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 0
+    lower = 0
+    upper = 10
+
+  [[medium]]
+    score = 2
+    lower = 10
+    upper = 20
+
+  [[high]]
+    score = 3
+    lower = 20
+    upper = 30
+
+  [[higher]]
+    score = 4
+    lower = 30
+    upper = 40
+
+  [[highest]]
+    score = 5
+    lower = 40
+    upper = 100
+
+#
+# Gene intolerance prediction
+#
+[gene_intolerance_score]
+  category = gene_intolerance_prediction
+  csq_key = LoFtool
+  data_type = float
+  description = LofTool gene intolerance prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[high_intolerance]]
+    score = 4
+    lower = 0
+    upper = 0.01
+
+  [[medium_intolerance]]
+    score = 2
+    lower = 0.01
+    upper = 0.1
+
+  [[low_intolerance]]
+    score = 0
+    lower = 0.1
+    upper = 1
+
+#
+# Inheritance models
+#
+[genetic_models]
+  category = inheritance_models
+  data_type = string
+  description = Inheritance models followed for the variant
+  field = INFO
+  info_key = GeneticModels
+  record_rule = max
+  separators = ',', ':', '|',
+
+  # These are all the same priority since they are mutually exclusive.
+  # We still give them priorities since genmod requires it for strings.
+  [[ad]]
+    score = 1
+    priority = 1
+    string = 'AD'
+
+  [[ad_dn]]
+    score = 1
+    priority = 1
+    string = 'AD_dn'
+
+  [[ar]]
+    score = 1
+    priority = 1
+    string = 'AR_hom'
+
+  [[ar_dn]]
+    score = 1
+    priority = 1
+    string = 'AR_hom_dn'
+
+  [[ar_comp]]
+    score = 1
+    priority = 1
+    string = 'AR_comp'
+
+  [[ar_comp_dn]]
+    score = 1
+    priority = 1
+    string = 'AR_comp_dn'
+
+  [[xr]]
+    score = 1
+    priority = 1
+    string = 'XR'
+
+  [[xr_dn]]
+    score = 1
+    priority = 1
+    string = 'XR_dn'
+
+  [[xd]]
+    score = 1
+    priority = 1
+    string = 'XD'
+
+  [[xd_dn]]
+    score = 1
+    priority = 1
+    string = 'XD_dn'
+
+  [[not_reported]]
+    score = -12
+
+#
+# Protein predictiion
+#
+[revel]
+  category = protein_prediction
+  csq_key = REVEL_score
+  data_type = float
+  description = Revel score prediction
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[tolerated]]
+    score = 0
+    lower = 0
+    upper = 0.5
+
+  [[probably_damaging]]
+    score = 2
+    lower = 0.5
+    upper = 0.75
+
+  [[damaging]]
+    score = 5
+    lower = 0.75
+    upper = 1
+
+#
+# Splicing
+#
+[spliceai_ds_ag]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_AG
+  data_type = float
+  description = SpliceAI delta score acceptor gain
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_al]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_AL
+  data_type = float
+  description = SpliceAI delta score acceptor loss
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_dg]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_DG
+  data_type = float
+  description = SpliceAI delta score donor gain
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+[spliceai_ds_dl]
+  category = splicing
+  csq_key = SpliceAI_pred_DS_DL
+  data_type = float
+  description = SpliceAI delta score donor loss
+  field = INFO
+  info_key = CSQ
+  record_rule = max
+  separators = ',',
+
+  [[not_reported]]
+    score = 0
+
+  [[low]]
+    score = 1
+    lower = 0
+    upper = 0.2
+
+  [[medium]]
+    score = 3
+    lower = 0.2
+    upper = 0.5
+
+  [[high]]
+    score = 5
+    lower = 0.5
+    upper = 100
+
+#
+# Variant call filter quality
+#
+[model_score]
+  category = variant_call_quality_filter
+  data_type = integer
+  description = Inheritance model score
+  field = INFO
+  info_key = ModelScore
+  record_rule = min
+  separators = ',',':',
+
+  [[not_reported]]
+    score = 0
+
+  [[low_qual]]
+    score = -5
+    lower = 0
+    upper = 10
+
+  [[medium_qual]]
+    score = -2
+    lower = 10
+    upper = 20
+
+  [[high_qual]]
+    score = 0
+    lower = 20
+    upper = 300
+
+[filter]
+  category = variant_call_quality_filter
+  data_type = string
+  description = The filters for the variant
+  field = FILTER
+  record_rule = min
+  separators = ';',
+
+  # Meaning this is not really in use. Each variant should get +3.
+  [[not_reported]]
+    score = 0
+
+  [[pass]]
+    score = 3
+    priority = 1
+    string = 'PASS'
+
+  [[dot]]
+    score = 3
+    priority = 2
+    string = '.'
+
+
+

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -9,7 +9,8 @@
     category_aggregation = min
 
   # For clinical significance (ClinVar), we include both the clinical significance and the review status.
-  # We want to sum the scores for both (why?), but we want to take the maximum score for each category.
+  # We currently sum the scores, but perhaps a nonlinear value would be more appropriate:
+  # i.e. an expert panel classification is more reliable than a single review, both in terms of setting a low or a high value for pathogenicity.
   [[clinical_significance]]
     category_aggregation = sum
 

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -31,7 +31,8 @@
   [[gene_intolerance_prediction]]
     category_aggregation = max
 
-  # Inheritance models is just one category from `genmod models`, could we just set max here for consistency?
+  # Inheritance models is just one category from `genmod models`.
+  # While min might be more appropriate if multiple categories were to be added, currently it doesn't matter.
   [[inheritance_models]]
     category_aggregation = min
 

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -19,7 +19,7 @@
     category_aggregation = max
 
   # For conservation (GERP++_RS, phastCons, phylop) we have multiple sources, each giving between 0 and 1.
-  # We want to sum the scores for all sources (why?).
+  # We currently sum the scores, since they are correlated but not perfectly so, making sum a more informative score than max.
   [[conservation]]
     category_aggregation = sum
 

--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini.md5
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini.md5
@@ -1,1 +1,0 @@
-5b1e82fb78f98e0a627a566b6c39769b  nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini

--- a/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini
@@ -3,30 +3,32 @@
   name = svrank_model
 
 [Categories]
- [[allele_frequency]]
-   category_aggregation = min
-
- [[clinical_significance]]
-   category_aggregation = sum
-
- [[consequence]]
-   category_aggregation = max
-
- [[gene_intolerance_prediction]]
-   category_aggregation = sum
-
- [[inheritance_models]]
-   category_aggregation = min
-
- [[variant_call_quality_filter]]
-   category_aggregate = sum
-
- [[variant_length]]
+  # We want to penalize common variants, the more common the lower score.
+  # Since we have multiple sources, we want to take the lowest score (most common) across all sources.
+  [[allele_frequency]]
     category_aggregation = min
 
- [[variant_type]]
+  # Consequence (most_severe_consequence) only has one source, and so doesn't really matter how we aggregate.
+  [[consequence]]
+    category_aggregation = max
+
+  # Gene intolerance prediction is just `most_severe_pli`, so it doesn't really matter how we aggregate.
+  [[gene_intolerance_prediction]]
+    category_aggregation = sum
+
+  # Inheritance models is just one category from `genmod models`, could we just set max here for consistency?
+  # A bit unclear how well they actually work for SVs.
+  [[inheritance_models]]
     category_aggregation = min
 
+  # An attempt to penalize small and very large SVs, which may be more likely to be false positives.
+  # It's possible this is completely unneccessary, and we should just rely on the allele frequency.
+  [[variant_length]]
+    category_aggregation = min
+
+#
+# Allele frequencies
+#
 [gnomad]
   category = allele_frequency
   data_type = float
@@ -46,7 +48,7 @@
 
   [[common]]
     score = -12
-    lower = 0.02
+    lower = 0.02 # This uses the same scoring as old MIP/RD models, as compared to loqusdb and colorsdb below.
     upper = 1.1
 
   [[intermediate]]
@@ -83,7 +85,7 @@
 
   [[common]]
     score = -12
-    lower = 0.05
+    lower = 0.05 # Uses 5% as the cutoff for common variants, since it's a smaller database.
     upper = 1.1
 
   [[intermediate]]
@@ -120,7 +122,7 @@
 
    [[common]]
     score = -12
-    lower = 0.05
+    lower = 0.05 # Uses 5% as the cutoff for common variants, since it's a smaller database.
     upper = 1.1
 
   [[intermediate]]
@@ -138,137 +140,9 @@
     lower = 0
     upper = 0.0005
 
-[sv_len]
-  category = variant_length
-  data_type = integer
-  description = The length of the structural variant
-  field = INFO
-  info_key = SVLEN
-  record_rule = min
-  separators = ',',
-
-  [[not_reported]]
-    score = 3
-
-  [[long_pos]]
-    score = 2
-    lower = 50000001
-    upper = 300000000
-
-  [[long_neg]]
-    score = 2
-    lower = -300000000
-    upper = -50000001
-
-  [[medium_pos]]
-    score = 3
-    lower = 401
-    upper = 50000000
-
-  [[medium_neg]]
-    score = 3
-    lower = -50000000
-    upper = -401
-
-  [[short_pos]]
-    score = 0
-    lower = 1
-    upper = 400
-
-  [[short_neg]]
-    score = 0
-    lower = -400
-    upper = -1
-
-[gene_intolerance_score]
-  category = gene_intolerance_prediction
-  data_type = float
-  description = Gnomad gene intolerance prediction
-  field = INFO
-  info_key = most_severe_pli
-  record_rule = max
-  separators = None
-
-  [[not_reported]]
-    score = 0
-
-  [[low_intolerance]]
-    score = 0
-    lower = 0
-    upper = 0.90
-
-  [[medium_intolerance]]
-    score = 2
-    lower = 0.90
-    upper = 0.99
-
-  [[high_intolerance]]
-    score = 4
-    lower = 0.99
-    upper = 1.1
-
-[genetic_models]
-  data_type = string
-  description = The inheritance models followed for the variant
-  category = inheritance_models
-  field = INFO
-  info_key = GeneticModels
-  record_rule = max
-  separators = ',', ':', '|',
-
-  [[ad]]
-    priority = 1
-    score = 3
-    string = 'AD'
-
-  [[ad_dn]]
-    priority = 1
-    score = 3
-    string = 'AD_dn'
-
-  [[ar]]
-    priority = 1
-    score = 3
-    string = 'AR_hom'
-
-  [[ar_dn]]
-    priority = 1
-    score = 3
-    string = 'AR_hom_dn'
-
-  [[ar_comp]]
-    priority = 1
-    score = 3
-    string = 'AR_comp'
-
-  [[ar_comp_dn]]
-    priority = 1
-    score = 3
-    string = 'AR_comp_dn'
-
-  [[xr]]
-    priority = 1
-    score = 3
-    string = 'XR'
-
-  [[xr_dn]]
-    priority = 1
-    score = 3
-    string = 'XR_dn'
-
-  [[xd]]
-    priority = 1
-    score = 3
-    string = 'XD'
-
-  [[xd_dn]]
-    priority = 1
-    score = 3
-    string = 'XD_dn'
-
-  [[not_reported]]
-    score = 0
-
+#
+# Consequence
+#
 [most_severe_consequence]
   category = consequence
   data_type = string
@@ -476,3 +350,152 @@
 
   [[not_reported]]
     score = 0
+
+#
+# Gene intolerance prediction
+#
+[gene_intolerance_score]
+  category = gene_intolerance_prediction
+  data_type = float
+  description = Gnomad gene intolerance prediction
+  field = INFO
+  info_key = most_severe_pli
+  record_rule = max
+  separators = None
+
+  [[not_reported]]
+    score = 0
+
+  [[low_intolerance]]
+    score = 0
+    lower = 0
+    upper = 0.90
+
+  [[medium_intolerance]]
+    score = 2
+    lower = 0.90
+    upper = 0.99
+
+  [[high_intolerance]]
+    score = 4
+    lower = 0.99
+    upper = 1.1
+
+#
+# Inheritance models
+#
+[genetic_models]
+  data_type = string
+  description = The inheritance models followed for the variant
+  category = inheritance_models
+  field = INFO
+  info_key = GeneticModels
+  record_rule = max
+  separators = ',', ':', '|',
+
+  # These are all the same priority since they are mutually exclusive.
+  # We still give them priorities since genmod requires it for strings.
+  [[ad]]
+    priority = 1
+    score = 3
+    string = 'AD'
+
+  [[ad_dn]]
+    priority = 1
+    score = 3
+    string = 'AD_dn'
+
+  [[ar]]
+    priority = 1
+    score = 3
+    string = 'AR_hom'
+
+  [[ar_dn]]
+    priority = 1
+    score = 3
+    string = 'AR_hom_dn'
+
+  [[ar_comp]]
+    priority = 1
+    score = 3
+    string = 'AR_comp'
+
+  [[ar_comp_dn]]
+    priority = 1
+    score = 3
+    string = 'AR_comp_dn'
+
+  [[xr]]
+    priority = 1
+    score = 3
+    string = 'XR'
+
+  [[xr_dn]]
+    priority = 1
+    score = 3
+    string = 'XR_dn'
+
+  [[xd]]
+    priority = 1
+    score = 3
+    string = 'XD'
+
+  [[xd_dn]]
+    priority = 1
+    score = 3
+    string = 'XD_dn'
+
+  [[not_reported]]
+    score = 0
+
+#
+# Variant length
+#
+[sv_len]
+  category = variant_length
+  data_type = integer
+  description = The length of the structural variant
+  field = INFO
+  info_key = SVLEN
+  record_rule = min
+  separators = ',',
+
+  [[not_reported]]
+    score = 3
+
+  # The idea of here is to slightly penalize very large SVs. If they come from Sniffles they are
+  # very likely to be false positives if they are deletions. However, if they are true variants they
+  # are likely to get a high score anyway, becasue they overlap many genes.
+  [[long_pos]]
+    score = 2
+    lower = 50000001
+    upper = 300000000
+
+  [[long_neg]]
+    score = 2
+    lower = -300000000
+    upper = -50000001
+
+  [[medium_pos]]
+    score = 3
+    lower = 401
+    upper = 50000000
+
+  # The lower 400 bp boundary is somewhat arbitrary and should perhaps be refined/removed.
+  # It's based on the idea that smaller SVs are more likely to be picked up by SNV/indel callers,
+  # and if they are uncommon and lie in a gene, they are likely to get a high score anyway.
+  [[medium_neg]]
+    score = 3
+    lower = -50000000
+    upper = -401
+
+  [[short_pos]]
+    score = 0
+    lower = 1
+    upper = 400
+
+  [[short_neg]]
+    score = 0
+    lower = -400
+    upper = -1
+

--- a/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini
@@ -16,7 +16,8 @@
   [[gene_intolerance_prediction]]
     category_aggregation = sum
 
-  # Inheritance models is just one category from `genmod models`, could we just set max here for consistency?
+  # Inheritance models is just one category from `genmod models`.
+  # While min might be more appropriate if multiple categories were to be added, currently it doesn't matter.
   # A bit unclear how well they actually work for SVs.
   [[inheritance_models]]
     category_aggregation = min

--- a/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini.md5
+++ b/nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini.md5
@@ -1,1 +1,0 @@
-e52d5ce7a5863e0f9a337dbfebf6db66  nallo/rank_model/grch38_rank_model_svs_-v1.0-.ini


### PR DESCRIPTION
## Description

Rank models need better descriptions of why they are written the way they are. This PR should not be changing anything expect as detailed below:

### Added

- Annotations to Nallo rank models 

### Changed

- Reorder and sort categories in Nallo rank models
- Removed md5sum files

### Fixed

- Removed unused `variant_call_quality_filter`, `clinical_significance` and `variant_type` sections of the Nallo SV rank model.