### PR TITLE
Remove model score from Nallo SNV score config

### DIFF
--- a/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
+++ b/nallo/rank_model/grch38_rank_model_snvs_-v1.0-.ini
@@ -845,33 +845,6 @@
 #
 # Variant call filter quality
 #
-[model_score]
-  category = variant_call_quality_filter
-  data_type = integer
-  description = Inheritance model score
-  field = INFO
-  info_key = ModelScore
-  record_rule = min
-  separators = ',',':',
-
-  [[not_reported]]
-    score = 0
-
-  [[low_qual]]
-    score = -5
-    lower = 0
-    upper = 10
-
-  [[medium_qual]]
-    score = -2
-    lower = 10
-    upper = 20
-
-  [[high_qual]]
-    score = 0
-    lower = 20
-    upper = 300
-
 [filter]
   category = variant_call_quality_filter
   data_type = string


### PR DESCRIPTION
## Description

Adresses #121. 

Number of SNVs uploaded with `charmedswan`:
- with model score: 3114
- without model score: 3114.

By removing ModelScore we are giving:
- 74 variants +2 RankScore (median 9, top 3 highest: 21, 16, 15)
- 8 variants +5 RankScore (median 9, top 3 highest: 14, 11, 10) 

of the 3042 variants with RankScore > 8.

ModelScore is not used in MIVMIR either. Best guess I think it should be pretty safely be able to remove this section of the rank model without significantly altering the rate of true and false positives.


### Changed

- Removed inheritance model score from Nallo SNV score config